### PR TITLE
Feat(#11): 회원가입/로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.7'
+    id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -27,6 +27,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/controller/AuthController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.skhu.gdgocteambuildingproject.auth.controller;
+
+import com.skhu.gdgocteambuildingproject.auth.dto.LoginRequestDto;
+import com.skhu.gdgocteambuildingproject.auth.dto.LoginResponseDto;
+import com.skhu.gdgocteambuildingproject.auth.dto.SignUpRequestDto;
+import com.skhu.gdgocteambuildingproject.auth.service.AuthService;
+import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+    private final UserRepository userRepository;
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<LoginResponseDto> signUp(@RequestBody @Valid SignUpRequestDto dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(authService.signUp(dto));
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto dto) {
+        return ResponseEntity.ok(authService.login(dto));
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/dto/LoginRequestDto.java
@@ -1,0 +1,15 @@
+package com.skhu.gdgocteambuildingproject.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/dto/LoginResponseDto.java
@@ -1,0 +1,13 @@
+package com.skhu.gdgocteambuildingproject.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponseDto {
+    private String accessToken;
+    private String email;
+    private String name;
+    private String role;
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/dto/SignUpRequestDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/dto/SignUpRequestDto.java
@@ -1,0 +1,39 @@
+package com.skhu.gdgocteambuildingproject.auth.dto;
+
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserPosition;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+@Getter
+public class SignUpRequestDto {
+
+    @NotBlank
+    private String name;
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank
+    @Pattern(regexp = "^(?=.*[!@#$%^&*(),.?\":{}|<>]).{8,}$", message = "비밀번호는 8자 이상이며 특수문자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank
+    private String passwordConfirm;
+
+    @NotBlank
+    private String number;
+
+    private String introduction;
+
+    @NotBlank
+    private String school;
+
+    private String generation;
+    private String part;
+
+    private UserPosition position; // MEMBER / CORE / ORGANIZER
+    private UserRole role;         // SKHU_MEMBER / OTHERS
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/service/AuthService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/service/AuthService.java
@@ -1,0 +1,74 @@
+package com.skhu.gdgocteambuildingproject.auth.service;
+
+import com.skhu.gdgocteambuildingproject.auth.dto.LoginRequestDto;
+import com.skhu.gdgocteambuildingproject.auth.dto.LoginResponseDto;
+import com.skhu.gdgocteambuildingproject.auth.dto.SignUpRequestDto;
+import com.skhu.gdgocteambuildingproject.global.jwt.TokenProvider;
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public LoginResponseDto signUp(SignUpRequestDto dto) {
+        if (userRepository.existsByEmail(dto.getEmail())) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
+        if (!dto.getPassword().equals(dto.getPasswordConfirm())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        User user = new User(
+                dto.getEmail(),
+                passwordEncoder.encode(dto.getPassword()),
+                dto.getName(),
+                dto.getNumber(),
+                dto.getIntroduction(),
+                dto.getSchool(),
+                dto.getRole(),
+                dto.getPosition(),
+                dto.getPart(),
+                dto.getGeneration()
+        );
+
+        userRepository.save(user);
+
+        String accessToken = tokenProvider.createAccessToken(user);
+
+        return new LoginResponseDto(
+                accessToken,
+                user.getEmail(),
+                user.getName(),
+                user.getRole().name()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public LoginResponseDto login(LoginRequestDto dto) {
+        User user = userRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        if (!user.isApproved()) {
+            throw new IllegalStateException("관리자 승인 대기 중입니다.");
+        }
+
+        String accessToken = tokenProvider.createAccessToken(user);
+        return new LoginResponseDto(accessToken, user.getEmail(), user.getName(), user.getRole().name());
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/config/JwtSecurityConfig.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/config/JwtSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.skhu.gdgocteambuildingproject.global.config;
+
+import com.skhu.gdgocteambuildingproject.global.jwt.JwtFilter;
+import com.skhu.gdgocteambuildingproject.global.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter jwtFilter = new JwtFilter(tokenProvider);
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.skhu.gdgocteambuildingproject.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class SecurityConfig {
+
+    // 비밀번호 암호화
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 회원가입만 허용하는 최소 설정
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(configurationSource()))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        .anyRequest().denyAll()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
+                )
+                .build();
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/JwtFilter.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/JwtFilter.java
@@ -1,0 +1,30 @@
+package com.skhu.gdgocteambuildingproject.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String jwt = tokenProvider.resolveToken((HttpServletRequest) request);
+
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/TokenProvider.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/TokenProvider.java
@@ -1,0 +1,88 @@
+package com.skhu.gdgocteambuildingproject.global.jwt;
+
+import com.skhu.gdgocteambuildingproject.global.jwt.service.CustomUserDetailsService;
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class TokenProvider {
+
+    private final Key key;
+    private final long accessTokenValidityTime;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    public TokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access.expiration}") long accessTokenValidityTime,
+            CustomUserDetailsService customUserDetailsService
+    ) {
+        byte[] keyBytes = secretKey.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidityTime = accessTokenValidityTime;
+        this.customUserDetailsService = customUserDetailsService;
+    }
+
+    // AccessToken 생성
+    public String createAccessToken(User user) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + accessTokenValidityTime);
+
+        return Jwts.builder()
+                .setSubject(user.getId().toString())
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰에서 사용자 인증 정보 추출
+    public Authentication getAuthentication(String token) {
+        String userPk = getUserPk(token);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(userPk);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    private String getUserPk(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    // 요청 헤더에서 Bearer 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("XXXXXX Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/service/CustomUserDetailsService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/service/CustomUserDetailsService.java
@@ -1,0 +1,23 @@
+package com.skhu.gdgocteambuildingproject.global.jwt.service;
+
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+//DB에서 유저를 찾아서 UserDetails 객체로 반환
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+        return new UserPrincipal(user);
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/service/UserPrincipal.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/service/UserPrincipal.java
@@ -1,0 +1,57 @@
+package com.skhu.gdgocteambuildingproject.global.jwt.service;
+
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+//Spring Security가 이해할 수 있는 사용자 정보 객체
+@Getter
+public class UserPrincipal implements UserDetails {
+
+    private final User user;
+
+    public UserPrincipal(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getId().toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    // 탈퇴/정지
+    @Override
+    public boolean isEnabled() {
+        return !user.isDeleted();
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/User.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/User.java
@@ -4,11 +4,6 @@ import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserPosition;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserRole;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,19 +17,9 @@ import java.util.List;
 @Table(name = "user")
 public class User extends BaseEntity {
 
-    @Email(message = "이메일 형식이 올바르지 않습니다.")
-    @NotBlank(message = "이메일은 필수 입력값입니다.")
     private String email;
-
-    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
-    @Pattern(
-            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-]).{8,}$",
-            message = "비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 합니다."
-    )
     private String password;
 
-    @Size(max = 5, message = "이름은 최대 5자까지 입력 가능합니다.")
     private String name;
     private String number;
     private String introduction;
@@ -49,6 +34,30 @@ public class User extends BaseEntity {
     private String part;
     private String generation;
     private boolean deleted;
+
+    // 승인 여부
+    @Column(nullable = false)
+    private boolean approved = false;
+
+    public void setApproved(boolean approved) {
+        this.approved = approved;
+    }
+
+    public User(String email, String password, String name, String number,
+                String introduction, String school, UserRole role, UserPosition position,
+                String part, String generation) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.number = number;
+        this.introduction = introduction;
+        this.school = school;
+        this.role = role;
+        this.position = position;
+        this.part = part;
+        this.generation = generation;
+        this.approved = true;
+    }
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TechStack> techStacks = new ArrayList<>();

--- a/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/enumtype/UserRole.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/enumtype/UserRole.java
@@ -1,6 +1,5 @@
 package com.skhu.gdgocteambuildingproject.user.domain.enumtype;
 
-
 public enum UserRole {
     BANNED, SKHU_ADMIN, SKHU_MEMBER, OTHERS
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/user/repository/UserRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.skhu.gdgocteambuildingproject.user.repository;
+
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,11 +37,9 @@ springdoc:
     display-request-duration: true
     groups-order: ASC
 
-#jwt:
-#  secretKey: ${JWT_SECRET_KEY}
-#  access:
-#    expiration: ${JWT_ACCESS_EXPIRATION}
-#    header: ${JWT_ACCESS_HEADER:Authorization}
-#  refresh:
-#    expiration: ${JWT_REFRESH_EXPIRATION}
-#    header: ${JWT_REFRESH_HEADER:RefreshToken}
+jwt:
+  secret: ${JWT_SECRET}
+  access:
+    expiration: ${JWT_ACCESS_EXPIRATION}
+  refresh:
+    expiration: ${JWT_REFRESH_EXPIRATION}


### PR DESCRIPTION
## 📝 PR 설명
> 관리자 승인시, 로그인 가능

## 🔍 관련 이슈
- #11 

## ✅ TODO
- [x] 회원가입
- [x] 로그인
- [x] 이메일 중복 확인 

## 기타
 > ⚠️회원가입 예외처리 (POST /auth/signup)

| 발생 조건 | 예외 메시지 | 예외 타입 | HTTP 상태코드 | 설명 |
|------------|-------------|-------------|----------------|------|
| 이미 가입된 이메일일 때 | `"이미 가입된 이메일입니다."` | `IllegalArgumentException` | **400 Bad Request** | `UserRepository.existsByEmail()` 중복 탐지 |
| 비밀번호와 비밀번호 확인이 다를 때 | `"비밀번호가 일치하지 않습니다."` | `IllegalArgumentException` | **400 Bad Request** | `dto.getPassword()` vs `dto.getPasswordConfirm()` 불일치 |
| `UserRole` 또는 `UserPosition` Enum 값이 유효하지 않을 때 | `JSON parse error: Cannot deserialize value...` | `HttpMessageNotReadableException` | **400 Bad Request** | JSON 필드 값이 Enum에 존재하지 않음 |
| 기타 런타임 예외 (예: DB 오류 등) | 예외 메시지에 따라 다름 | `RuntimeException` | **500 Internal Server Error** | 예기치 않은 서버 오류 |

 > ⚠️ 로그인 예외 처리 (POST /auth/login)

| 발생 조건 | 예외 메시지 | 예외 타입 | HTTP 상태코드 | 설명 |
|------------|-------------|------------|----------------|------|
| 이메일이 존재하지 않을 때 | `"존재하지 않는 이메일입니다."` | `IllegalArgumentException` | **400 Bad Request** | DB에서 해당 이메일을 찾을 수 없음 |
| 비밀번호가 틀릴 때 | `"비밀번호가 일치하지 않습니다."` | `IllegalArgumentException` | **400 Bad Request** | `passwordEncoder.matches()`가 `false` |
| 관리자 승인 전 계정일 때 | `"관리자 승인 대기 중입니다."` | `IllegalStateException` | **403 Forbidden** | `user.isApproved()`가 `false` |
| 기타 런타임 예외 | 예외 메시지에 따라 다름 | `RuntimeException` | **500 Internal Server Error** | 서버 내부 오류 발생 |

