### PR TITLE
feat(team building): 모집 중인 아이디어만 조회 기능 추가

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/Idea/domain/Idea.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/Idea/domain/Idea.java
@@ -33,6 +33,9 @@ public class Idea extends BaseEntity {
     private String title;
     private String introduction;
     private String description;
+    // TODO: 모든 인원이 다 차면 false로 상태 전이
+    @Builder.Default
+    private Boolean recruiting = true;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/skhu/gdgocteambuildingproject/Idea/repository/IdeaRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/Idea/repository/IdeaRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface IdeaRepository extends JpaRepository<Idea, Long> {
     Page<Idea> findByProjectId(long projectId, Pageable pageable);
 
+    Page<Idea> findByProjectIdAndRecruitingIsTrue(long projectId, Pageable pageable);
+
     Optional<Idea> findByIdAndProjectId(long ideaId, long projectId);
 
     Optional<Idea> findByCreatorAndProject(User creator, TeamBuildingProject project);

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/TeamBuildingController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/TeamBuildingController.java
@@ -76,13 +76,15 @@ public class TeamBuildingController {
 
     @GetMapping("/projects/{projectId}/ideas")
     @Operation(
-            summary = "아이디어 조회",
+            summary = "아이디어 목록 조회",
             description = """
                     프로젝트에 게시된 아이디어 목록을 조회합니다.
                     
                     sortBy(정렬 기준): id(순번), topic(주제), title(제목), introduction(한줄 소개), description(설명)
                     
                     order: ASC 또는 DESC
+                    
+                    recruitingOnly: 모집 중인 아이디어만 보기(인원이 최대로 차지 않은 아이디어만 보기)
                     """
     )
     public ResponseEntity<IdeaTitleInfoPageResponseDto> findIdeas(
@@ -90,16 +92,17 @@ public class TeamBuildingController {
             @RequestParam int page,
             @RequestParam int size,
             @RequestParam String sortBy,
-            @RequestParam SortOrder order
+            @RequestParam SortOrder order,
+            @RequestParam boolean recruitingOnly
     ) {
-        IdeaTitleInfoPageResponseDto response = ideaService.findIdeas(projectId, page, size, sortBy, order);
+        IdeaTitleInfoPageResponseDto response = ideaService.findIdeas(projectId, page, size, sortBy, order, recruitingOnly);
 
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/projects/{projectId}/ideas/{ideaId}")
     @Operation(
-            summary = "아이디어 조회",
+            summary = "아이디어 상세 조회",
             description = """
                     프로젝트에 게시된 아이디어 하나의 상세 정보를 조회합니다.
                     

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
@@ -18,7 +18,8 @@ public interface IdeaService {
             int page,
             int size,
             String sortBy,
-            SortOrder order
+            SortOrder order,
+            boolean recruitingOnly
     );
 
     IdeaDetailInfoResponseDto findIdeaDetail(

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -63,11 +63,12 @@ public class IdeaServiceImpl implements IdeaService {
             int page,
             int size,
             String sortBy,
-            SortOrder order
+            SortOrder order,
+            boolean recruitingOnly
     ) {
         Pageable pagination = setupPagination(page, size, sortBy, order);
 
-        Page<Idea> ideas = ideaRepository.findByProjectId(projectId, pagination);
+        Page<Idea> ideas = findPagedIdeasOf(projectId, pagination, recruitingOnly);
         List<IdeaTitleInfoResponseDto> ideaDtos = ideas
                 .stream()
                 .map(ideaTitleInfoMapper::map)
@@ -89,6 +90,14 @@ public class IdeaServiceImpl implements IdeaService {
                 .orElseThrow(() -> new IllegalArgumentException(IDEA_NOT_EXIST.getMessage()));
 
         return ideaDetailInfoMapper.map(idea);
+    }
+
+    private Page<Idea> findPagedIdeasOf(long projectId, Pageable pagination, boolean recruitingOnly) {
+        if (recruitingOnly) {
+            return ideaRepository.findByProjectIdAndRecruitingIsTrue(projectId, pagination);
+        }
+
+        return ideaRepository.findByProjectId(projectId, pagination);
     }
 
     private Idea postNewIdea(


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

아이디어 목록 조회 API에서, 모집 중인 아이디어만 조회할지 선택할 수 있는 기능을 추가했습니다.
이를 위해 아이디어에 `recruiting` 속성을 추가했습니다.

## 🔍 관련 이슈
- #65 

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.

`recruiting` 속성은 기본적으로 true로 초기화되고, 모든 멤버가 모집되면 false로 변경될 예정입니다.
해당 속성의 전이는, 이후에 신청 API에서 구현할 예정입니다.