### PR TITLE
 feat(team building): 지원하기 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/Idea/domain/Idea.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/Idea/domain/Idea.java
@@ -140,6 +140,20 @@ public class Idea extends BaseEntity {
         return registerStatus == IdeaStatus.TEMPORARY;
     }
 
+    public boolean isEnrollmentAvailable(Part part) {
+        long currentCount = members.stream()
+                .filter(member -> member.getPart() == part)
+                .count();
+
+        Integer maxMemberCount = memberCompositions.stream()
+                .filter(composition -> composition.getPart() == part)
+                .map(IdeaMemberComposition::getCount)
+                .findAny()
+                .orElse(0);
+
+        return currentCount < maxMemberCount;
+    }
+
     private Map<Part, Integer> initCurrentCounts() {
         EnumMap<Part, Integer> partMap = new EnumMap<>(Part.class);
 

--- a/src/main/java/com/skhu/gdgocteambuildingproject/Idea/domain/IdeaEnrollment.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/Idea/domain/IdeaEnrollment.java
@@ -3,11 +3,14 @@ package com.skhu.gdgocteambuildingproject.Idea.domain;
 import com.skhu.gdgocteambuildingproject.Idea.domain.enumtype.EnrollmentStatus;
 import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.Choice;
 import com.skhu.gdgocteambuildingproject.user.domain.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -31,18 +34,26 @@ import lombok.NoArgsConstructor;
         }
 )
 public class IdeaEnrollment extends BaseEntity {
-    private String choice;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Choice choice;
+
+    @Column(nullable = false)
     private String part;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private EnrollmentStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private Idea idea;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+    @JoinColumn(nullable = false)
+    private User applicant;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private ProjectSchedule schedule;
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
@@ -11,6 +11,7 @@ public enum ExceptionMessage {
 
     // TeamBuilding
     SCHEDULE_NOT_EXIST("일정이 존재하지 않습니다."),
+    ENROLLMENT_NOT_AVAILABLE("지원할 수 없는 상태입니다."),
     PROJECT_NOT_EXIST("프로젝트가 존재하지 않습니다."),
     IDEA_NOT_EXIST("아이디어가 존재하지 않습니다."),
     REGISTERED_IDEA_ALREADY_EXIST("등록한 아이디어가 이미 존재합니다."),

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/EnrollmentController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/EnrollmentController.java
@@ -1,0 +1,60 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.controller;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.EnrollmentAvailabilityResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.service.EnrollmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/enrollments")
+@PreAuthorize("hasAnyRole('SKHU_ADMIN', 'SKHU_MEMBER', 'OTHERS')")
+@Tag(
+        name = "지원 API",
+        description = "'SKHU_ADMIN', 'SKHU_MEMBER', 'OTHERS' 중 하나의 권한이 있어야 호출할 수 있습니다."
+)
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    @GetMapping("/availability/ideas/{ideaId}")
+    @Operation(
+            summary = "지원하기 정보 조회",
+            description = """
+                    '지원하기' 페이지를 렌더링할 때 필요한 정보를 조회합니다.
+                    
+                    현재 지원 가능한 일정이 아닐 경우 4XX 응답을 반환합니다.
+                    
+                    현재 진행 중인 프로젝트 일정 정보, 지원한 아이디어에 대한 정보, 각 지망 사용 가능 여부, 지원 가능 파트 정보를 반환합니다.
+                    
+                    scheduleType: IDEA_REGISTRATION, FIRST_TEAM_BUILDING, FIRST_TEAM_BUILDING_ANNOUNCEMENT, SECOND_TEAM_BUILDING, SECOND_TEAM_BUILDING_ANNOUNCEMENT, THIRD_TEAM_BUILDING, FINAL_RESULT_ANNOUNCEMENT
+                    지원 가능한 일정에 대해서만 동작하기 때문에, 실제로는 FIRST_TEAM_BUILDING, SECOND_TEAM_BUILDING만 반환할 것입니다.
+                    
+                    choice: FIRST, SECOND, THIRD
+                    
+                    part: PM, DESIGN, WEB, MOBILE, BACKEND, AI
+                    """
+    )
+    private ResponseEntity<EnrollmentAvailabilityResponseDto> getEnrollmentInfo(
+            Principal principal,
+            @PathVariable long ideaId
+    ) {
+        long userId = findUserIdBy(principal);
+
+        EnrollmentAvailabilityResponseDto response = enrollmentService.getAvailabilityInfo(ideaId, userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    private long findUserIdBy(Principal principal) {
+        return Long.parseLong(principal.getName());
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectSchedule.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectSchedule.java
@@ -35,6 +35,10 @@ public class ProjectSchedule extends BaseEntity {
     @JoinColumn(nullable = false)
     private TeamBuildingProject project;
 
+    public boolean isEnrollmentAvailable() {
+        return type.isEnrollmentAvailable();
+    }
+
     public boolean scheduledStartDate() {
         return startDate != null;
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
@@ -12,6 +12,7 @@ import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -75,5 +76,14 @@ public class TeamBuildingProject extends BaseEntity {
 
             schedules.add(schedule);
         }
+    }
+
+    public Optional<ProjectSchedule> getCurrentSchedule() {
+        LocalDateTime now = LocalDateTime.now();
+
+        return schedules.stream()
+                .filter(schedule -> now.isAfter(schedule.getStartDate()))
+                .filter(schedule -> now.isBefore(schedule.getEndDate()))
+                .findFirst();
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/Choice.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/Choice.java
@@ -1,0 +1,5 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype;
+
+public enum Choice {
+    FIRST, SECOND, THIRD
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/ScheduleType.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/ScheduleType.java
@@ -1,11 +1,20 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype;
 
+import lombok.Getter;
+
+@Getter
 public enum ScheduleType {
-    IDEA_REGISTRATION,
-    FIRST_TEAM_BUILDING,
-    FIRST_TEAM_BUILDING_ANNOUNCEMENT,
-    SECOND_TEAM_BUILDING,
-    SECOND_TEAM_BUILDING_ANNOUNCEMENT,
-    THIRD_TEAM_BUILDING,
-    FINAL_RESULT_ANNOUNCEMENT
+    IDEA_REGISTRATION(false),
+    FIRST_TEAM_BUILDING(true),
+    FIRST_TEAM_BUILDING_ANNOUNCEMENT(false),
+    SECOND_TEAM_BUILDING(true),
+    SECOND_TEAM_BUILDING_ANNOUNCEMENT(false),
+    THIRD_TEAM_BUILDING(false),
+    FINAL_RESULT_ANNOUNCEMENT(false);
+
+    private final boolean enrollmentAvailable;
+
+    ScheduleType(boolean enrollmentAvailable) {
+        this.enrollmentAvailable = enrollmentAvailable;
+    }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/ChoiceAvailabilityResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/ChoiceAvailabilityResponseDto.java
@@ -1,0 +1,11 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.dto.response;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.Choice;
+import lombok.Builder;
+
+@Builder
+public record ChoiceAvailabilityResponseDto(
+        Choice choice,
+        boolean available
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/EnrollmentAvailabilityResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/EnrollmentAvailabilityResponseDto.java
@@ -1,0 +1,23 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.dto.response;
+
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record EnrollmentAvailabilityResponseDto(
+        String projectName,
+        ScheduleType scheduleType,
+
+        String ideaTitle,
+        String ideaIntroduction,
+
+        String creatorSchool,
+        Part creatorPart,
+        String creatorName,
+
+        List<ChoiceAvailabilityResponseDto> choiceAvailabilities,
+        List<PartAvailabilityResponseDto> partAvailabilities
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/PartAvailabilityResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/PartAvailabilityResponseDto.java
@@ -1,0 +1,11 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.dto.response;
+
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import lombok.Builder;
+
+@Builder
+public record PartAvailabilityResponseDto(
+        Part part,
+        boolean available
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ChoiceAvailabilityMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ChoiceAvailabilityMapper.java
@@ -1,0 +1,32 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.model;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.Choice;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.ChoiceAvailabilityResponseDto;
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChoiceAvailabilityMapper {
+    public List<ChoiceAvailabilityResponseDto> map(
+            User applicant,
+            ProjectSchedule schedule
+    ) {
+        return Arrays.stream(Choice.values())
+                .map(choice -> createDtoOf(choice, applicant, schedule))
+                .toList();
+    }
+
+    private ChoiceAvailabilityResponseDto createDtoOf(
+            Choice choice,
+            User applicant,
+            ProjectSchedule schedule
+    ) {
+        return ChoiceAvailabilityResponseDto.builder()
+                .choice(choice)
+                .available(applicant.isChoiceAvailable(schedule, choice))
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/EnrollmentAvailabilityMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/EnrollmentAvailabilityMapper.java
@@ -1,0 +1,37 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.model;
+
+import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.EnrollmentAvailabilityResponseDto;
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EnrollmentAvailabilityMapper {
+    private final PartAvailabilityMapper partMapper;
+    private final ChoiceAvailabilityMapper choiceMapper;
+
+    public EnrollmentAvailabilityResponseDto map(
+            TeamBuildingProject project,
+            ProjectSchedule schedule,
+            Idea idea,
+            User applicant
+    ) {
+        User creator = idea.getCreator();
+
+        return EnrollmentAvailabilityResponseDto.builder()
+                .projectName(project.getName())
+                .scheduleType(schedule.getType())
+                .ideaTitle(idea.getTitle())
+                .ideaIntroduction(idea.getIntroduction())
+                .creatorSchool(creator.getSchool())
+                .creatorPart(creator.getPart())
+                .creatorName(creator.getName())
+                .choiceAvailabilities(choiceMapper.map(applicant, schedule))
+                .partAvailabilities(partMapper.map(idea))
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/PartAvailabilityMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/PartAvailabilityMapper.java
@@ -1,0 +1,27 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.model;
+
+import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PartAvailabilityResponseDto;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartAvailabilityMapper {
+    public List<PartAvailabilityResponseDto> map(Idea idea) {
+        return Arrays.stream(Part.values())
+                .map(part -> getDtoOf(part, idea))
+                .toList();
+    }
+
+    private PartAvailabilityResponseDto getDtoOf(
+            Part part,
+            Idea idea
+    ) {
+        return PartAvailabilityResponseDto.builder()
+                .part(part)
+                .available(idea.isEnrollmentAvailable(part))
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/EnrollmentService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/EnrollmentService.java
@@ -1,0 +1,10 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.service;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.EnrollmentAvailabilityResponseDto;
+
+public interface EnrollmentService {
+    EnrollmentAvailabilityResponseDto getAvailabilityInfo(
+            long ideaId,
+            long applicantId
+    );
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/EnrollmentServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/EnrollmentServiceImpl.java
@@ -1,0 +1,65 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.service;
+
+import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.ENROLLMENT_NOT_AVAILABLE;
+import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.IDEA_NOT_EXIST;
+import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.USER_NOT_EXIST;
+
+import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
+import com.skhu.gdgocteambuildingproject.Idea.repository.IdeaRepository;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.EnrollmentAvailabilityResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.model.EnrollmentAvailabilityMapper;
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentServiceImpl implements EnrollmentService {
+
+    private final IdeaRepository ideaRepository;
+    private final UserRepository userRepository;
+
+    private final EnrollmentAvailabilityMapper availabilityMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public EnrollmentAvailabilityResponseDto getAvailabilityInfo(
+            long ideaId,
+            long applicantId
+    ) {
+        Idea idea = findIdeaBy(ideaId);
+        TeamBuildingProject project = idea.getProject();
+        ProjectSchedule currentSchedule = findCurrentSchedule(project);
+        User applicant = findUserBy(applicantId);
+
+        validateEnrollmentAvailable(currentSchedule);
+
+        return availabilityMapper.map(project, currentSchedule, idea, applicant);
+    }
+
+    private Idea findIdeaBy(long ideaId) {
+        return ideaRepository.findById(ideaId)
+                .orElseThrow(() -> new EntityNotFoundException(IDEA_NOT_EXIST.getMessage()));
+    }
+
+    private ProjectSchedule findCurrentSchedule(TeamBuildingProject project) {
+        return project.getCurrentSchedule()
+                .orElseThrow(() -> new IllegalStateException(ENROLLMENT_NOT_AVAILABLE.getMessage()));
+    }
+
+    private User findUserBy(long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(USER_NOT_EXIST.getMessage()));
+    }
+
+    private void validateEnrollmentAvailable(ProjectSchedule schedule) {
+        if (!schedule.isEnrollmentAvailable()) {
+            throw new IllegalStateException(ENROLLMENT_NOT_AVAILABLE.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/User.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/User.java
@@ -1,21 +1,29 @@
 package com.skhu.gdgocteambuildingproject.user.domain;
 
 import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
+import com.skhu.gdgocteambuildingproject.Idea.domain.IdeaEnrollment;
 import com.skhu.gdgocteambuildingproject.auth.domain.RefreshToken;
 import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
 import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.Choice;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.ApprovalStatus;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserPosition;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserRole;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -60,6 +68,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Idea> ideas = new ArrayList<>();
 
+    @OneToMany(mappedBy = "applicant", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<IdeaEnrollment> enrollments = new ArrayList<>();
+
     @Builder
     public User(String email, String password, String name, String number,
                 String introduction, String school, UserRole role, UserPosition position,
@@ -86,6 +97,12 @@ public class User extends BaseEntity {
 
     public void reject() {
         this.approvalStatus = ApprovalStatus.REJECTED;
+    }
+
+    public boolean isChoiceAvailable(ProjectSchedule schedule, Choice choice) {
+        return enrollments.stream()
+                .filter(enrollment -> enrollment.getSchedule().equals(schedule))
+                .noneMatch(enrollment -> enrollment.getChoice().equals(choice));
     }
 
     /**


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

'지원하기' 페이지에서 요구하는 정보를 제공하는 API를 구현했습니다.
`Idea` 엔티티의 연관관계 구조를 수정했습니다.
`int choice`에 대한 `enum` 타입 `Choice`를 생성했습니다.

## 🔍 관련 이슈
- #20 

## ✅ TODO
- [x] 현재 일정에 관한 정보를 반환한다.
- [x] 지원하고자 하는 아이디어에 관한 정보를 반환한다.
- [x] 아이디어 작성자에 대한 정보를 반환한다.
- [x] 사용 가능한 지망 정보를 반환한다.
- [x] 지원 가능한 파트 정보를 반환한다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.

PR 볼륨을 최대한 줄이려고 노력했으나, API 구현을 위해 필요한 기능이 많아 고봉밥 PR이 되었습니다...
양해 바랍니다 🥲