### PR TITLE
feat(admin): 관리자용 아이디어 삭제 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminIdeaManageApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminIdeaManageApi.java
@@ -1,0 +1,20 @@
+package com.skhu.gdgocteambuildingproject.admin.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "관리자 아이디어 관리 API", description = "관리자용 아이디어 관리 API입니다")
+public interface AdminIdeaManageApi {
+
+    @Operation(
+            summary = "아이디어 삭제",
+            description = """
+                    아이디어를 제거합니다.
+                    관련된 지원 정보도 모두 같이 제거됩니다.
+                    
+                    사용자가 본인의 아이디어를 삭제할 때와 달리, 실제로 DB에서 제거되어 복구할 수 없습니다.
+                    """
+    )
+    ResponseEntity<Void> deleteIdea(long ideaId);
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminIdeaManageController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminIdeaManageController.java
@@ -1,0 +1,31 @@
+package com.skhu.gdgocteambuildingproject.admin.controller;
+
+import com.skhu.gdgocteambuildingproject.admin.api.AdminIdeaManageApi;
+import com.skhu.gdgocteambuildingproject.teambuilding.service.IdeaService;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/ideas")
+@PreAuthorize("hasAnyRole('SKHU_ADMIN')")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminIdeaManageController implements AdminIdeaManageApi {
+
+    private static final ResponseEntity<Void> NO_CONTENT = ResponseEntity.noContent().build();
+
+    private final IdeaService ideaService;
+
+    @Override
+    @DeleteMapping("/{ideaId}")
+    public ResponseEntity<Void> deleteIdea(@PathVariable long ideaId) {
+        ideaService.hardDeleteIdea(ideaId);
+
+        return NO_CONTENT;
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/TeamBuildingController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/TeamBuildingController.java
@@ -171,7 +171,7 @@ public class TeamBuildingController {
     ) {
         long userId = getUserIdFrom(principal);
 
-        ideaService.deleteIdea(projectId, ideaId, userId);
+        ideaService.softDeleteIdea(projectId, ideaId, userId);
 
         return NO_CONTENT;
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
@@ -32,9 +32,13 @@ public interface IdeaService {
             long userId
     );
 
-    void deleteIdea(
+    void softDeleteIdea(
             long projectId,
             long ideaId,
             long userId
+    );
+
+    void hardDeleteIdea(
+            long ideaId
     );
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -118,7 +118,7 @@ public class IdeaServiceImpl implements IdeaService {
 
     @Override
     @Transactional
-    public void deleteIdea(
+    public void softDeleteIdea(
             long projectId,
             long ideaId,
             long userId
@@ -127,6 +127,12 @@ public class IdeaServiceImpl implements IdeaService {
                 .orElseThrow(() -> new EntityNotFoundException(IDEA_NOT_EXIST.getMessage()));
 
         idea.delete();
+    }
+
+    @Override
+    @Transactional
+    public void hardDeleteIdea(long ideaId) {
+        ideaRepository.deleteById(ideaId);
     }
 
     private void validateContents(IdeaCreateRequestDto requestDto) {


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

관리자를 위한 아이디어 삭제 API를 구현했습니다.

## 🔍 관련 이슈
- #75 

## ✅ TODO
- [x] 관리자 권한을 요구합니다.
- [x] 아이디어를 실제 DB에서 제거합니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.