### PR TITLE
feat(admin): 프로젝트 기간 등록 및 수정 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminProjectManageApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminProjectManageApi.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.admin.api;
 
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectCreateRequestDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,4 +22,17 @@ public interface AdminProjectManageApi {
             description = "과거에 진행된 프로젝트 목록을 조회합니다."
     )
     ResponseEntity<List<PastProjectResponseDto>> getPastProjects();
+
+    @Operation(
+            summary = "프로젝트 일정 등록 및 수정",
+            description = """
+                    프로젝트의 일정 기간을 등록 혹은 수정합니다.
+                    
+                    scheduleType: IDEA_REGISTRATION, FIRST_TEAM_BUILDING, FIRST_TEAM_BUILDING_ANNOUNCEMENT, SECOND_TEAM_BUILDING, SECOND_TEAM_BUILDING_ANNOUNCEMENT, THIRD_TEAM_BUILDING, FINAL_RESULT_ANNOUNCEMENT
+                    """
+    )
+    ResponseEntity<Void> updateSchedule(
+            long projectId,
+            ScheduleUpdateRequestDto requestDto
+    );
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminProjectManageController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminProjectManageController.java
@@ -2,6 +2,7 @@ package com.skhu.gdgocteambuildingproject.admin.controller;
 
 import com.skhu.gdgocteambuildingproject.admin.api.AdminProjectManageApi;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectCreateRequestDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.service.ProjectService;
 import jakarta.validation.Valid;
@@ -11,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,5 +45,16 @@ public class AdminProjectManageController implements AdminProjectManageApi {
         List<PastProjectResponseDto> response = projectService.findPastProjects();
 
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PutMapping("/{projectId}/schedule")
+    public ResponseEntity<Void> updateSchedule(
+            @PathVariable long projectId,
+            @Valid @RequestBody ScheduleUpdateRequestDto requestDto
+    ) {
+        projectService.updateSchedule(projectId, requestDto);
+
+        return NO_CONTENT;
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/project/ScheduleUpdateRequestDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/project/ScheduleUpdateRequestDto.java
@@ -1,0 +1,15 @@
+package com.skhu.gdgocteambuildingproject.admin.dto.project;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record ScheduleUpdateRequestDto(
+        @NotNull
+        ScheduleType scheduleType,
+        @NotNull
+        LocalDateTime startAt,
+        @NotNull
+        LocalDateTime endAt
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
@@ -11,6 +11,7 @@ public enum ExceptionMessage {
 
     // TeamBuilding
     SCHEDULE_NOT_EXIST("일정이 존재하지 않습니다."),
+    ILLEGAL_SCHEDULE_DATE("일정의 날짜가 부적절합니다."),
     ENROLLMENT_NOT_AVAILABLE("지원할 수 없는 상태입니다."),
     PROJECT_NOT_EXIST("프로젝트가 존재하지 않습니다."),
     IDEA_NOT_EXIST("아이디어가 존재하지 않습니다."),

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectSchedule.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectSchedule.java
@@ -2,6 +2,7 @@ package com.skhu.gdgocteambuildingproject.teambuilding.domain;
 
 
 import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
+import com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -45,5 +46,28 @@ public class ProjectSchedule extends BaseEntity {
 
     public boolean isEnrollmentAvailable() {
         return type.isEnrollmentAvailable();
+    }
+
+    public void updateDates(
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    ) {
+        validateDates(startDate, endDate);
+
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    private void validateDates(
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    ) {
+        if (startDate == null || endDate == null) {
+            throw new IllegalArgumentException(ExceptionMessage.ILLEGAL_SCHEDULE_DATE.getMessage());
+        }
+
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException(ExceptionMessage.ILLEGAL_SCHEDULE_DATE.getMessage());
+        }
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.domain;
 
 import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.SCHEDULE_ALREADY_INITIALIZED;
+import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.SCHEDULE_NOT_EXIST;
 
 import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
 import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
@@ -87,5 +88,18 @@ public class TeamBuildingProject extends BaseEntity {
                 .filter(schedule -> now.isAfter(schedule.getStartDate()))
                 .filter(schedule -> now.isBefore(schedule.getEndDate()))
                 .findFirst();
+    }
+
+    public void updateSchedule(
+            ScheduleType scheduleType,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    ) {
+        ProjectSchedule projectSchedule = schedules.stream()
+                .filter(schedule -> schedule.getType() == scheduleType)
+                .findAny()
+                .orElseThrow(() -> new IllegalStateException(SCHEDULE_NOT_EXIST.getMessage()));
+
+        projectSchedule.updateDates(startDate, endDate);
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectService.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.service;
 
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectCreateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.TeamBuildingInfoResponseDto;
@@ -11,4 +12,6 @@ public interface ProjectService {
     TeamBuildingInfoResponseDto findCurrentProjectInfo(long userId);
 
     List<PastProjectResponseDto> findPastProjects();
+
+    void updateSchedule(long projectId, ScheduleUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectServiceImpl.java
@@ -3,6 +3,7 @@ package com.skhu.gdgocteambuildingproject.teambuilding.service;
 import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.PROJECT_NOT_EXIST;
 import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.USER_NOT_EXIST;
 
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectCreateRequestDto;
@@ -72,9 +73,26 @@ public class ProjectServiceImpl implements ProjectService {
                 .toList();
     }
 
+    @Override
+    @Transactional
+    public void updateSchedule(long projectId, ScheduleUpdateRequestDto requestDto) {
+        TeamBuildingProject project = findProjectBy(projectId);
+
+        project.updateSchedule(
+                requestDto.scheduleType(),
+                requestDto.startAt(),
+                requestDto.endAt()
+        );
+    }
+
     private User findUserBy(long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_EXIST.getMessage()));
+    }
+
+    private TeamBuildingProject findProjectBy(long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException(PROJECT_NOT_EXIST.getMessage()));
     }
 
     private TeamBuildingProject findUnscheduledProject(List<TeamBuildingProject> projects) {


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

관리자 페이지에서 프로젝트 기간을 등록하거나 수정하는 API를 구현했습니다.
PUT을 기반으로 해서 한 API에서 등록/수정을 같이 할 수 있도록 구현했습니다.
관리자 기능이니 만큼, 일정의 `startDate`와 `endDate`가 적절한지는 가볍게만 검증했습니다.


## 🔍 관련 이슈
- #9 

## ✅ TODO
- [x] 관리자 권한을 요구한다.
- [x] 프로젝트 일정의 시작일과 종료일을 수정한다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.

프로젝트의 일정 자체는 처음 프로젝트가 생성될 때 `TeamBuildingProject.initSchedules` 메서드로 초기화됩니다.