### PR TITLE
feat(admin): 아이디어 조회 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/Idea/repository/IdeaRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/Idea/repository/IdeaRepository.java
@@ -7,11 +7,23 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IdeaRepository extends JpaRepository<Idea, Long> {
     Page<Idea> findByProjectId(long projectId, Pageable pageable);
 
     Page<Idea> findByProjectIdAndRecruitingIsTrue(long projectId, Pageable pageable);
+
+    @Query(
+            value = "SELECT * FROM idea WHERE project_id = :project_id",
+            countQuery = "SELECT count(*) FROM idea WHERE project_id = :project_id",
+            nativeQuery = true
+    )
+    Page<Idea> findByProjectIdIncludeDeleted(
+            @Param("project_id") long projectId,
+            Pageable pageable
+    );
 
     Optional<Idea> findByIdAndProjectId(long ideaId, long projectId);
 

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminIdeaManageApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminIdeaManageApi.java
@@ -1,11 +1,19 @@
 package com.skhu.gdgocteambuildingproject.admin.api;
 
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
+import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "관리자 아이디어 관리 API", description = "관리자용 아이디어 관리 API입니다")
 public interface AdminIdeaManageApi {
+
+    String DEFAULT_PAGE = "0";
+    String DEFAULT_SIZE = "20";
+    String DEFAULT_SORT_BY = "id";
+    String DEFAULT_ORDER = "ASC";
 
     @Operation(
             summary = "아이디어 삭제",
@@ -16,5 +24,28 @@ public interface AdminIdeaManageApi {
                     사용자가 본인의 아이디어를 삭제할 때와 달리, 실제로 DB에서 제거되어 복구할 수 없습니다.
                     """
     )
-    ResponseEntity<Void> deleteIdea(long ideaId);
+    ResponseEntity<Void> deleteIdea(
+            @Parameter(description = "삭제할 아이디어의 ID") long ideaId
+    );
+
+    @Operation(
+            summary = "아이디어 조회",
+            description = """
+                    아이디어를 조회합니다.
+                    소프트 딜리트된 아이디어도 포함해 조회합니다.
+                    
+                    아이디어의 소프트 딜리트 여부도 같이 반환합니다.
+                    
+                    sortBy(정렬 기준): id(순번), topic(주제), title(제목), introduction(한줄 소개), description(설명)
+                    
+                    order: ASC 또는 DESC
+                    """
+    )
+    ResponseEntity<IdeaTitleInfoIncludeDeletedPageResponseDto> findIdeas(
+            @Parameter(description = "프로젝트 ID") long projectId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") int page,
+            @Parameter(description = "페이지 당 항목 수", example = "20") int size,
+            @Parameter(description = "정렬 기준 필드명 (id, topic, title, introduction, description)", example = "id") String sortBy,
+            @Parameter(description = "정렬 순서 (ASC 또는 DESC)") SortOrder order
+    );
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminIdeaManageController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminIdeaManageController.java
@@ -1,18 +1,22 @@
 package com.skhu.gdgocteambuildingproject.admin.controller;
 
 import com.skhu.gdgocteambuildingproject.admin.api.AdminIdeaManageApi;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
+import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import com.skhu.gdgocteambuildingproject.teambuilding.service.IdeaService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/admin/ideas")
+@RequestMapping("/admin")
 @PreAuthorize("hasAnyRole('SKHU_ADMIN')")
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class AdminIdeaManageController implements AdminIdeaManageApi {
@@ -22,10 +26,30 @@ public class AdminIdeaManageController implements AdminIdeaManageApi {
     private final IdeaService ideaService;
 
     @Override
-    @DeleteMapping("/{ideaId}")
+    @DeleteMapping("/ideas/{ideaId}")
     public ResponseEntity<Void> deleteIdea(@PathVariable long ideaId) {
         ideaService.hardDeleteIdea(ideaId);
 
         return NO_CONTENT;
+    }
+
+    @Override
+    @GetMapping("/projects/{projectId}/ideas")
+    public ResponseEntity<IdeaTitleInfoIncludeDeletedPageResponseDto> findIdeas(
+            @PathVariable long projectId,
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
+            @RequestParam(defaultValue = DEFAULT_SORT_BY) String sortBy,
+            @RequestParam(defaultValue = DEFAULT_ORDER) SortOrder order
+    ) {
+        IdeaTitleInfoIncludeDeletedPageResponseDto response = ideaService.findIdeasIncludeDeleted(
+                projectId,
+                page,
+                size,
+                sortBy,
+                order
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/idea/IdeaTitleInfoIncludeDeletedPageResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/idea/IdeaTitleInfoIncludeDeletedPageResponseDto.java
@@ -1,0 +1,12 @@
+package com.skhu.gdgocteambuildingproject.admin.dto.idea;
+
+import com.skhu.gdgocteambuildingproject.global.pagination.PageInfo;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record IdeaTitleInfoIncludeDeletedPageResponseDto(
+        List<IdeaTitleInfoIncludeDeletedResponseDto> ideas,
+        PageInfo pageInfo
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/idea/IdeaTitleInfoIncludeDeletedResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/idea/IdeaTitleInfoIncludeDeletedResponseDto.java
@@ -1,0 +1,14 @@
+package com.skhu.gdgocteambuildingproject.admin.dto.idea;
+
+import lombok.Builder;
+
+@Builder
+public record IdeaTitleInfoIncludeDeletedResponseDto(
+    long ideaId,
+    String title,
+    String introduction,
+    int currentMemberCount,
+    int maxMemberCount,
+    boolean deleted
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/IdeaTitleInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/IdeaTitleInfoMapper.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.model;
 
 import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaTitleInfoResponseDto;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,17 @@ public class IdeaTitleInfoMapper {
                 .introduction(idea.getIntroduction())
                 .currentMemberCount(idea.getCurrentMemberCount())
                 .maxMemberCount(idea.getMaxMemberCount())
+                .build();
+    }
+
+    public IdeaTitleInfoIncludeDeletedResponseDto mapIncludeDeleted(Idea idea) {
+        return IdeaTitleInfoIncludeDeletedResponseDto.builder()
+                .ideaId(idea.getId())
+                .title(idea.getTitle())
+                .introduction(idea.getIntroduction())
+                .currentMemberCount(idea.getCurrentMemberCount())
+                .maxMemberCount(idea.getMaxMemberCount())
+                .deleted(idea.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.service;
 
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.request.IdeaCreateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaDetailInfoResponseDto;
@@ -20,6 +21,14 @@ public interface IdeaService {
             String sortBy,
             SortOrder order,
             boolean recruitingOnly
+    );
+
+    IdeaTitleInfoIncludeDeletedPageResponseDto findIdeasIncludeDeleted(
+            long projectId,
+            int page,
+            int size,
+            String sortBy,
+            SortOrder order
     );
 
     IdeaDetailInfoResponseDto findIdeaDetail(

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -10,6 +10,8 @@ import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessag
 import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
 import com.skhu.gdgocteambuildingproject.Idea.domain.enumtype.IdeaStatus;
 import com.skhu.gdgocteambuildingproject.Idea.repository.IdeaRepository;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedResponseDto;
 import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
 import com.skhu.gdgocteambuildingproject.global.pagination.PageInfo;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
@@ -86,6 +88,29 @@ public class IdeaServiceImpl implements IdeaService {
                 .toList();
 
         return IdeaTitleInfoPageResponseDto.builder()
+                .ideas(ideaDtos)
+                .pageInfo(PageInfo.from(ideas))
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public IdeaTitleInfoIncludeDeletedPageResponseDto findIdeasIncludeDeleted(
+            long projectId,
+            int page,
+            int size,
+            String sortBy,
+            SortOrder order
+    ) {
+        Pageable pagination = setupPagination(page, size, sortBy, order);
+
+        Page<Idea> ideas = ideaRepository.findByProjectIdIncludeDeleted(projectId, pagination);
+
+        List<IdeaTitleInfoIncludeDeletedResponseDto> ideaDtos = ideas.stream()
+                .map(ideaTitleInfoMapper::mapIncludeDeleted)
+                .toList();
+
+        return IdeaTitleInfoIncludeDeletedPageResponseDto.builder()
                 .ideas(ideaDtos)
                 .pageInfo(PageInfo.from(ideas))
                 .build();


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

관리자용 아이디어 조회 API를 구현했습니다.
소프트 딜리트된 아이디어를 포함해 조회하며, 기존 아이디어 조회 API의 응답 값에 '소프트 딜리트 여부'를 더해 반환합니다.

## 🔍 관련 이슈
- #76 

## ✅ TODO
- [x] 소프트 딜리트된 아이디어도 같이 조회한다.
- [x] 아이디어의 소프트 딜리트 여부를 같이 반환한다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.