### PR TITLE
fix(team building): 프록시로 인해 동등 비교에 실패하던 문제 수정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/entity/BaseEntity.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/entity/BaseEntity.java
@@ -26,11 +26,10 @@ public abstract class BaseEntity {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof BaseEntity otherBaseEntity)) {
             return false;
         }
-        BaseEntity that = (BaseEntity) o;
-        return Objects.equals(id, that.id);
+        return Objects.equals(id, otherBaseEntity.id);
     }
 
     @Override


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

`BaseEntity`의 `equals`가 `getClass`를 사용함으로 인해 프록시 객체 간 동등 비교에 실패하는 문제를 해결했습니다.