### PR TITLE
fix(dto): DTO의 `getter` 메서드가 Swagger에 필드로 표시되는 문제 수정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/request/IdeaCreateRequestDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/request/IdeaCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.skhu.gdgocteambuildingproject.Idea.domain.enumtype.IdeaStatus;
 import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
 import java.util.List;
@@ -13,6 +14,7 @@ public record IdeaCreateRequestDto(
         IdeaStatus registerStatus,
         List<IdeaMemberCompositionRequestDto> compositions
 ) {
+    @JsonIgnore
     public List<String> getTexts() {
         return List.of(title, introduction, description, topic);
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/request/IdeaTextUpdateRequestDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/request/IdeaTextUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 public record IdeaTextUpdateRequestDto(
@@ -8,6 +9,7 @@ public record IdeaTextUpdateRequestDto(
         String description,
         String topic
 ) {
+    @JsonIgnore
     public List<String> getTexts() {
         return List.of(title, introduction, description, topic);
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/request/IdeaUpdateRequestDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/request/IdeaUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
 import java.util.List;
 
@@ -11,6 +12,7 @@ public record IdeaUpdateRequestDto(
         Part creatorPart,
         List<IdeaMemberCompositionRequestDto> compositions
 ) {
+    @JsonIgnore
     public List<String> getTexts() {
         return List.of(title, introduction, description, topic);
     }


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

DTO의 `getTexts` 메서드가 `getter` 형태임에 의해 Swagger에서 요청 필드로 표시되던 문제를 해결했습니다.