### PR TITLE
feat(team building): 수정 가능한 프로젝트 조회 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminProjectManageApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminProjectManageApi.java
@@ -2,6 +2,7 @@ package com.skhu.gdgocteambuildingproject.admin.api;
 
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectCreateRequestDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectInfoPageResponseDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectTotalResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
@@ -47,6 +48,18 @@ public interface AdminProjectManageApi {
             description = "과거에 진행된 프로젝트 목록을 조회합니다."
     )
     ResponseEntity<List<PastProjectResponseDto>> getPastProjects();
+
+    @Operation(
+            summary = "수정 가능한 프로젝트 조회",
+            description = """
+                    아직 시작하지 않은 프로젝트 중 시작 일자가 가장 빠른 프로젝트를 조회합니다.
+                    
+                    일정이 모두 결정된 프로젝트가 없다면, 아직 일정이 정해지지 않은 프로젝트를 조회합니다.
+                    
+                    해당하는 프로젝트가 존재하지 않는다면 404를 응답합니다.
+                    """
+    )
+    ResponseEntity<ProjectTotalResponseDto> getModifiableProject();
 
     @Operation(
             summary = "프로젝트 일정 등록 및 수정",

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminProjectManageController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminProjectManageController.java
@@ -3,6 +3,7 @@ package com.skhu.gdgocteambuildingproject.admin.controller;
 import com.skhu.gdgocteambuildingproject.admin.api.AdminProjectManageApi;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectCreateRequestDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectInfoPageResponseDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectTotalResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
@@ -59,6 +60,14 @@ public class AdminProjectManageController implements AdminProjectManageApi {
     @GetMapping("/past")
     public ResponseEntity<List<PastProjectResponseDto>> getPastProjects() {
         List<PastProjectResponseDto> response = projectService.findPastProjects();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/modifiable")
+    public ResponseEntity<ProjectTotalResponseDto> getModifiableProject() {
+        ProjectTotalResponseDto response = projectService.findUpdatableProject();
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/project/ProjectAvailablePartResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/project/ProjectAvailablePartResponseDto.java
@@ -1,0 +1,11 @@
+package com.skhu.gdgocteambuildingproject.admin.dto.project;
+
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import lombok.Builder;
+
+@Builder
+public record ProjectAvailablePartResponseDto(
+        Part part,
+        boolean available
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/project/ProjectTotalResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/project/ProjectTotalResponseDto.java
@@ -1,0 +1,15 @@
+package com.skhu.gdgocteambuildingproject.admin.dto.project;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.ProjectScheduleResponseDto;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ProjectTotalResponseDto(
+        Long projectId,
+        String projectName,
+        int maxMemberCount,
+        List<ProjectAvailablePartResponseDto> availableParts,
+        List<ProjectScheduleResponseDto> schedules
+) {
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
@@ -51,12 +51,26 @@ public class TeamBuildingProject extends BaseEntity {
                 .toList();
     }
 
+    public boolean isAvailable(Part part) {
+        return availableParts.stream()
+                .map(ProjectAvailablePart::getPart)
+                .anyMatch(availablePart -> availablePart == part);
+    }
+
     public boolean isScheduled() {
+        if (schedules.isEmpty()) {
+            return false;
+        }
+
         return schedules.stream()
                 .allMatch(ProjectSchedule::isScheduled);
     }
 
     public boolean isUnscheduled() {
+        if (schedules.isEmpty()) {
+            return true;
+        }
+
         return schedules.stream()
                 .anyMatch(ProjectSchedule::isUnscheduled);
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectAvailablePartMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectAvailablePartMapper.java
@@ -1,0 +1,27 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.model;
+
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectAvailablePartResponseDto;
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectAvailablePartMapper {
+    public List<ProjectAvailablePartResponseDto> map(TeamBuildingProject project) {
+        List<ProjectAvailablePartResponseDto> dtos = new ArrayList<>();
+
+        for (Part part : Part.values()) {
+            ProjectAvailablePartResponseDto dto = ProjectAvailablePartResponseDto.builder()
+                    .part(part)
+                    .available(project.isAvailable(part))
+                    .build();
+
+            dtos.add(dto);
+        }
+
+        return Collections.unmodifiableList(dtos);
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectTotalMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectTotalMapper.java
@@ -1,0 +1,23 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.model;
+
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectTotalResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProjectTotalMapper {
+    private final ProjectAvailablePartMapper availablePartMapper;
+    private final ProjectScheduleMapper scheduleMapper;
+
+    public ProjectTotalResponseDto map(TeamBuildingProject project) {
+        return ProjectTotalResponseDto.builder()
+                .projectId(project.getId())
+                .projectName(project.getName())
+                .maxMemberCount(project.getMaxMemberCount())
+                .availableParts(availablePartMapper.map(project))
+                .schedules(scheduleMapper.map(project.getSchedules()))
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/TeamBuildingProjectRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/TeamBuildingProjectRepository.java
@@ -42,4 +42,21 @@ public interface TeamBuildingProjectRepository extends JpaRepository<TeamBuildin
             @Param("type") ScheduleType type,
             @Param("criteria") LocalDateTime criteria
     );
+
+    @Query("""
+    SELECT DISTINCT p
+    FROM TeamBuildingProject p
+    LEFT JOIN FETCH p.schedules
+    WHERE EXISTS (
+        SELECT 1
+        FROM ProjectSchedule s
+        WHERE s.project = p
+          AND s.type = :type
+          AND (s.startDate IS NULL OR s.startDate > :criteria)
+    )
+    """)
+    List<TeamBuildingProject> findProjectsWithScheduleNotStarted(
+            @Param("type") ScheduleType type,
+            @Param("criteria") LocalDateTime criteria
+    );
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectService.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.service;
 
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectInfoPageResponseDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectTotalResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.PastProjectResponseDto;
@@ -21,6 +22,8 @@ public interface ProjectService {
     TeamBuildingInfoResponseDto findCurrentProjectInfo(long userId);
 
     List<PastProjectResponseDto> findPastProjects();
+
+    ProjectTotalResponseDto findUpdatableProject();
 
     void updateSchedule(long projectId, ScheduleUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/ProjectServiceImpl.java
@@ -5,6 +5,7 @@ import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessag
 
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectInfoPageResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectInfoResponseDto;
+import com.skhu.gdgocteambuildingproject.admin.dto.project.ProjectTotalResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.project.ScheduleUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.PageInfo;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
@@ -15,6 +16,7 @@ import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.TeamBuildingInfoResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.PastProjectMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.ProjectInfoMapper;
+import com.skhu.gdgocteambuildingproject.teambuilding.model.ProjectTotalMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.ProjectUtil;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.TeamBuildingInfoMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.repository.TeamBuildingProjectRepository;
@@ -42,6 +44,7 @@ public class ProjectServiceImpl implements ProjectService {
     private final TeamBuildingInfoMapper teamBuildingInfoMapper;
     private final PastProjectMapper pastProjectMapper;
     private final ProjectInfoMapper projectInfoMapper;
+    private final ProjectTotalMapper projectTotalMapper;
 
     @Override
     @Transactional
@@ -96,6 +99,14 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public ProjectTotalResponseDto findUpdatableProject() {
+        TeamBuildingProject project = findModifiableProject();
+
+        return projectTotalMapper.map(project);
+    }
+
+    @Override
     @Transactional
     public void updateSchedule(long projectId, ScheduleUpdateRequestDto requestDto) {
         TeamBuildingProject project = findProjectBy(projectId);
@@ -122,6 +133,11 @@ public class ProjectServiceImpl implements ProjectService {
                 ScheduleType.FINAL_RESULT_ANNOUNCEMENT,
                 criteriaTime
         );
+    }
+
+    private TeamBuildingProject findModifiableProject() {
+        return projectUtil.findModifiableProject()
+                .orElseThrow(() -> new EntityNotFoundException(PROJECT_NOT_EXIST.getMessage()));
     }
 
     private Pageable setupPagination(


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

관리자가 프로젝트를 수정할 때 사용할 수 있도록, 수정 가능한 프로젝트를 조회하는 API를 구현합니다.

## 🔍 관련 이슈
- #166 

## ✅ TODO
- [x] 아직 시작하지 않은 프로젝트 중 가장 빠르게 시작할 프로젝트를 응답한다.
- [x] 일정이 정해진 프로젝트가 없다면, 일정이 정해지지 않은 프로젝트를 응답한다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.