### PR TITLE
feat(team building): 멤버에 대한 프로젝트 접근 권한 검증 로직 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
@@ -29,6 +29,7 @@ public enum ExceptionMessage {
     PASSWORD_SAME_AS_OLD("새 비밀번호는 기존 비밀번호와 달라야 합니다."),
 
     // TeamBuilding
+    NOT_PARTICIPATED("프로젝트에 접근 권한이 없습니다."),
     SCHEDULE_NOT_EXIST("일정이 존재하지 않습니다."),
     NOT_REGISTRATION_SCHEDULE("아이디어 등록 기간이 아닙니다."),
     SCHEDULE_PASSED("일정이 지났습니다."),

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectParticipant.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectParticipant.java
@@ -1,0 +1,37 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.domain;
+
+import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
+import com.skhu.gdgocteambuildingproject.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "UK_PROJECT_USER",
+                        columnNames = {"project_id", "user_id"}
+                )
+        }
+)
+public class ProjectParticipant extends BaseEntity {
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private TeamBuildingProject project;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private User user;
+}

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
@@ -1,10 +1,12 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.model;
 
+import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.NOT_PARTICIPATED;
 import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage.PROJECT_NOT_EXIST;
 
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
+import com.skhu.gdgocteambuildingproject.teambuilding.repository.ProjectParticipantRepository;
 import com.skhu.gdgocteambuildingproject.teambuilding.repository.TeamBuildingProjectRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
@@ -18,7 +20,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProjectUtil {
 
+    private final ProjectParticipantRepository participantRepository;
     private final TeamBuildingProjectRepository projectRepository;
+
+    public void validateParticipation(long userId, long projectId) {
+        boolean participated = participantRepository.existsByUserIdAndProjectId(userId, projectId);
+
+        if (!participated) {
+            throw new IllegalStateException(NOT_PARTICIPATED.getMessage());
+        }
+    }
 
     public Optional<TeamBuildingProject> findCurrentProject() {
         List<TeamBuildingProject> unfinishedProjects = findUnfinishedProjects();

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/ProjectParticipantRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/ProjectParticipantRepository.java
@@ -1,0 +1,8 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.repository;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectParticipantRepository extends JpaRepository<ProjectParticipant, Long> {
+    boolean existsByUserIdAndProjectId(long userId, long projectId);
+}


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

멤버가 해당 프로젝트에 참여 가능한지 여부를 저장하는 엔티티를 생성했습니다.
접근 권한을 편리하게 검증할 수 있는 유틸 메서드를 구현했습니다.

## 🔍 관련 이슈
- #105 

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.

엔티티를 다른 기능에서도 사용해야 하기에, 기능만 우선 구현했습니다.
실제로 권한을 검사하는 로직은 추후에 적용하겠습니다.