### PR TITLE
feat(team building): 프로젝트 조회 API에서 지원 가능 여부도 조회하도록 개선

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/TeamBuildingInfoResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/response/TeamBuildingInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.dto.response;
 
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
 import java.util.List;
 import lombok.Builder;
 
@@ -10,6 +11,7 @@ public record TeamBuildingInfoResponseDto(
         int maxMemberCount,
         boolean registrable,
         boolean canEnroll,
-        List<ProjectScheduleResponseDto> schedules
+        List<ProjectScheduleResponseDto> schedules,
+        List<Part> availableParts
 ) {
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/TeamBuildingInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/TeamBuildingInfoMapper.java
@@ -21,6 +21,7 @@ public class TeamBuildingInfoMapper {
                 .registrable(isRegistrable(project, user))
                 .canEnroll(isCanEnroll(project, user))
                 .schedules(scheduleMapper.map(project.getSchedules()))
+                .availableParts(project.getAvailableParts())
                 .build();
     }
 


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

프로젝트 조회 API가, 본인이 다른 아이디어에 지원할 수 있는지 여부도 같이 응답하도록 개선했습니다.
또한, 해당 프로젝트에서 허용된 파트 정보도 같이 응답하도록 개선했습니다.

## 🔍 관련 이슈
- #110 
- #148 

## ✅ TODO
- [x] 아이디어를 게시한 회원이라면 false를 반환합니다.
- [x] 게시한 아이디어가 없는 회원이라면 true를 반환합니다.
- [x] 프로젝트에 허용된 파트 정보도 같이 반환합니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.