### PR TITLE
feat(admin): 관리자용 아이디어 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminIdeaManageApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminIdeaManageApi.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.admin.api;
 
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.AdminIdeaDetailResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.request.IdeaUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
@@ -49,6 +50,22 @@ public interface AdminIdeaManageApi {
             @Parameter(description = "페이지 당 항목 수", example = "20") int size,
             @Parameter(description = "정렬 기준 필드명 (id, topic, title, introduction, description)", example = "id") String sortBy,
             @Parameter(description = "정렬 순서 (ASC 또는 DESC)") SortOrder order
+    );
+
+    @Operation(
+            summary = "아이디어 상세 조회",
+            description = """
+                    프로젝트에 게시된 아이디어 하나의 상세 정보를 조회합니다.
+                    소프트 딜리트된 아이디어도 조회할 수 있습니다.
+                    
+                    아이디어의 소프트 딜리트 여부도 같이 반환합니다.
+                    
+                    part: PM, DESIGN, WEB, MOBILE, BACKEND, AI
+                    """
+    )
+    ResponseEntity<AdminIdeaDetailResponseDto> findIdeaDetail(
+            @Parameter(description = "프로젝트 ID") long projectId,
+            @Parameter(description = "아이디어 ID") long ideaId
     );
 
     @Operation(

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminIdeaManageController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/controller/AdminIdeaManageController.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.admin.controller;
 
 import com.skhu.gdgocteambuildingproject.admin.api.AdminIdeaManageApi;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.AdminIdeaDetailResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.request.IdeaUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
@@ -52,6 +53,20 @@ public class AdminIdeaManageController implements AdminIdeaManageApi {
                 size,
                 sortBy,
                 order
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/projects/{projectId}/ideas/{ideaId}")
+    public ResponseEntity<AdminIdeaDetailResponseDto> findIdeaDetail(
+            @PathVariable long projectId,
+            @PathVariable long ideaId
+    ) {
+        AdminIdeaDetailResponseDto response = ideaService.findIdeaDetailByAdmin(
+                projectId,
+                ideaId
         );
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/idea/AdminIdeaDetailResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/idea/AdminIdeaDetailResponseDto.java
@@ -1,0 +1,19 @@
+package com.skhu.gdgocteambuildingproject.admin.dto.idea;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaCreatorInfoResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaMemberCompositionResponseDto;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record AdminIdeaDetailResponseDto(
+        Long ideaId,
+        String title,
+        String introduction,
+        String description,
+        IdeaCreatorInfoResponseDto creator,
+        boolean deleted,
+        List<IdeaMemberCompositionResponseDto> compositions
+) {
+}
+

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/IdeaDetailInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/IdeaDetailInfoMapper.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.model;
 
 import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.AdminIdeaDetailResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaCreatorInfoResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaDetailInfoResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.response.IdeaMemberCompositionResponseDto;
@@ -26,6 +27,21 @@ public class IdeaDetailInfoMapper {
                 .description(idea.getDescription())
                 .creator(creator)
                 .compositions(compositions)
+                .build();
+    }
+
+    public AdminIdeaDetailResponseDto mapForAdmin(Idea idea) {
+        IdeaCreatorInfoResponseDto creator = creatorInfoMapper.map(idea);
+        List<IdeaMemberCompositionResponseDto> compositions = compositionMapper.map(idea);
+
+        return AdminIdeaDetailResponseDto.builder()
+                .ideaId(idea.getId())
+                .title(idea.getTitle())
+                .introduction(idea.getIntroduction())
+                .description(idea.getDescription())
+                .creator(creator)
+                .compositions(compositions)
+                .deleted(idea.isDeleted())
                 .build();
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.service;
 
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.AdminIdeaDetailResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.request.IdeaTextUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.request.IdeaUpdateRequestDto;
@@ -34,6 +35,11 @@ public interface IdeaService {
     );
 
     IdeaDetailInfoResponseDto findIdeaDetail(
+            long projectId,
+            long ideaId
+    );
+
+    AdminIdeaDetailResponseDto findIdeaDetailByAdmin(
             long projectId,
             long ideaId
     );

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -15,6 +15,7 @@ import static com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessag
 import com.skhu.gdgocteambuildingproject.Idea.domain.Idea;
 import com.skhu.gdgocteambuildingproject.Idea.domain.enumtype.IdeaStatus;
 import com.skhu.gdgocteambuildingproject.Idea.repository.IdeaRepository;
+import com.skhu.gdgocteambuildingproject.admin.dto.idea.AdminIdeaDetailResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
 import com.skhu.gdgocteambuildingproject.admin.dto.idea.IdeaTitleInfoIncludeDeletedResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.request.IdeaTextUpdateRequestDto;
@@ -139,6 +140,20 @@ public class IdeaServiceImpl implements IdeaService {
                 .orElseThrow(() -> new IllegalArgumentException(IDEA_NOT_EXIST.getMessage()));
 
         return ideaDetailInfoMapper.map(idea);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminIdeaDetailResponseDto findIdeaDetailByAdmin(
+            long projectId,
+            long ideaId
+    ) {
+        Idea idea = ideaRepository.findByIdIncludeDeleted(ideaId)
+                .orElseThrow(() -> new IllegalArgumentException(IDEA_NOT_EXIST.getMessage()));
+
+        validateIdeaInProject(idea, projectId);
+
+        return ideaDetailInfoMapper.mapForAdmin(idea);
     }
 
     @Override


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

관리자가 사용할 '아이디어 상세 조회 API'를 구현했습니다.
기존의 아이디어 상세 조회 API와 유사하되, 소프트 딜리트된 아이디어도 조회할 수 있으며, 소프트 딜리트 여부를 같이 응답합니다.

## 🔍 관련 이슈
- #140 

## ✅ TODO
- [x] 아이디어의 상세 정보를 조회한다.
- [x] 소프트 딜리트된 아이디어도 조회할 수 있다.
- [x] 아이디어의 소프트 딜리트 여부도 같이 응답한다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.