### PR TITLE
chore(deploy): 배포 환경 DB를 RDS에서 Docker의 MySQL 컨테이너로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,9 +131,13 @@ jobs:
             docker stop teamBuildingSystem-app || true
             docker rm   teamBuildingSystem-app || true
             
-            # 4) 새 컨테이너 실행 (env-file 기반)
+            # 3-1) Docker 네트워크 없으면 생성
+            docker network create tbs-network || true
+            
+            # 4) 새 컨테이너 실행 (env-file 기반, mysql 컨테이너와 네트워크 연결)
             docker run -d --name teamBuildingSystem-app --restart unless-stopped \
             --env-file "$ENV_FILE" \
+            --network tbs-network \
             -p 8080:8080 \
             "$IMAGE"
             


### PR DESCRIPTION
## 📝 PR 설명
배포 환경에서 사용하는 DB를 변경했습니다
- 기존 DB : AWS RDS의 인스턴스의 DB(요금 개비쌈ㅠ)
- 변경된 DB : mysql이 설치된 docker 컨테이너의 DB

## 🔍 관련 이슈
- #212 

## ✅ TODO
- [ ] Github Secrets의 환경변수 값(엔드포인트, username, password)을 mysql이 설치된  docker 컨테이너 DB의 값으로 변경
- [ ] 서로 다른 컨테이너간 통신이 가능하도록 docker network 생성 및 컨테이너 연결
- [ ] 배포 환경에서 새로운 컨테이너 생성시 해당 network에 연결되도록 설정

## 기타