### PR TITLE
fix(team building): 스케줄러가 모집 마감을 기준으로 동작하도록 수정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
@@ -106,6 +106,8 @@ public class TeamBuildingProject extends BaseEntity {
             ProjectSchedule schedule = ProjectSchedule.builder()
                     .type(type)
                     .project(this)
+                    // 발표 일정이 아니라면 confirm할 일이 없어서 true로 초기화
+                    .confirmed(!type.isAnnouncement())
                     .build();
 
             schedules.add(schedule);
@@ -120,6 +122,18 @@ public class TeamBuildingProject extends BaseEntity {
                 .filter(schedule -> now.isAfter(schedule.getStartDate()))
                 .filter(schedule -> now.isBefore(schedule.getEndDate()))
                 .findFirst();
+    }
+
+    public Optional<ProjectSchedule> getPreviousScheduleOf(ScheduleType scheduleType) {
+        if (scheduleType == null) {
+            return Optional.empty();
+        }
+
+        ScheduleType prevScheduleType = scheduleType.getPrevScheduleType();
+
+        return getSchedules().stream()
+                .filter(schedule -> schedule.getType() == prevScheduleType)
+                .findAny();
     }
 
     public ProjectSchedule getScheduleFrom(ScheduleType scheduleType) {

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/ScheduleType.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/ScheduleType.java
@@ -1,25 +1,71 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype;
 
+import java.util.function.Supplier;
 import lombok.Getter;
 
 @Getter
 public enum ScheduleType {
-    IDEA_REGISTRATION(false, true),
-    FIRST_TEAM_BUILDING(true, true),
-    FIRST_TEAM_BUILDING_ANNOUNCEMENT(false, false),
-    SECOND_TEAM_BUILDING(true, false),
-    SECOND_TEAM_BUILDING_ANNOUNCEMENT(false, false),
-    THIRD_TEAM_BUILDING(false, false),
-    FINAL_RESULT_ANNOUNCEMENT(false, false);
+    IDEA_REGISTRATION(
+            false,
+            true,
+            false,
+            () -> null
+    ),
+    FIRST_TEAM_BUILDING(
+            true,
+            true,
+            false,
+            () -> IDEA_REGISTRATION
+    ),
+    FIRST_TEAM_BUILDING_ANNOUNCEMENT(
+            false,
+            false,
+            true,
+            () -> FIRST_TEAM_BUILDING
+    ),
+    SECOND_TEAM_BUILDING(
+            true,
+            false,
+            false,
+            () -> FIRST_TEAM_BUILDING_ANNOUNCEMENT
+    ),
+    SECOND_TEAM_BUILDING_ANNOUNCEMENT(
+            false,
+            false,
+            true,
+            () -> SECOND_TEAM_BUILDING
+    ),
+    THIRD_TEAM_BUILDING(
+            false,
+            false,
+            false,
+            () -> SECOND_TEAM_BUILDING_ANNOUNCEMENT
+    ),
+    FINAL_RESULT_ANNOUNCEMENT(
+            false,
+            false,
+            true,
+            () -> THIRD_TEAM_BUILDING
+    );
 
     private final boolean enrollmentAvailable;
     private final boolean ideaDeletable;
+    private final boolean announcement;
+    private final Supplier<ScheduleType> prevScheduleType;
 
     ScheduleType(
             boolean enrollmentAvailable,
-            boolean ideaDeletable
+            boolean ideaDeletable,
+            boolean announcement,
+            Supplier<ScheduleType> prevScheduleType
     ) {
         this.enrollmentAvailable = enrollmentAvailable;
         this.ideaDeletable = ideaDeletable;
+        this.announcement = announcement;
+        this.prevScheduleType = prevScheduleType;
+    }
+
+    public ScheduleType getPrevScheduleType() {
+        return prevScheduleType.get();
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/ProjectScheduleRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/ProjectScheduleRepository.java
@@ -8,12 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ProjectScheduleRepository extends JpaRepository<ProjectSchedule, Long> {
+
     @Query("""
         SELECT s
         FROM ProjectSchedule s
         WHERE s.confirmed = false
-          AND s.endDate < :now
+          AND s.startDate < :now
         """)
-    List<ProjectSchedule> findUnconfirmedSchedulesEndedBefore(@Param("now") LocalDateTime now);
+    List<ProjectSchedule> findUnconfirmedSchedulesStartedBefore(@Param("now") LocalDateTime now);
 }
 


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

스케줄러가 모집 일정의 `endDate`를 기준으로 동작하고 있던 문제를 해결했습니다.
이젠 스케줄러가 모집 마감 일정의 `startDate`를 기준으로 동작합니다.

## 🔍 관련 이슈
- #111 

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.