### PR TITLE
fix(team building): 종료되지 않은 프로젝트 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/TeamBuildingProjectRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/TeamBuildingProjectRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TeamBuildingProjectRepository extends JpaRepository<TeamBuildingProject, Long> {
+
     @Query("""
     SELECT DISTINCT p
     FROM TeamBuildingProject p
@@ -35,27 +36,10 @@ public interface TeamBuildingProjectRepository extends JpaRepository<TeamBuildin
         FROM ProjectSchedule s
         WHERE s.project = p
           AND s.type = :type
-          AND s.endDate > :criteria
+          AND (s.endDate IS NULL OR s.endDate > :criteria)
     )
     """)
     List<TeamBuildingProject> findProjectsWithScheduleNotEndedBefore(
-            @Param("type") ScheduleType type,
-            @Param("criteria") LocalDateTime criteria
-    );
-
-    @Query("""
-    SELECT DISTINCT p
-    FROM TeamBuildingProject p
-    LEFT JOIN FETCH p.schedules
-    WHERE EXISTS (
-        SELECT 1
-        FROM ProjectSchedule s
-        WHERE s.project = p
-          AND s.type = :type
-          AND (s.startDate IS NULL OR s.startDate > :criteria)
-    )
-    """)
-    List<TeamBuildingProject> findProjectsWithScheduleNotStarted(
             @Param("type") ScheduleType type,
             @Param("criteria") LocalDateTime criteria
     );


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

종료되지 않은 프로젝트를 조회하는 쿼리를 수정했습니다.
기존에는 `null` 처리 로직이 없어서, 일정이 설정되지 않은 프로젝트가 조회 대상에 포함되지 않았습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.