### PR TITLE
fix(admin): 프로젝트를 삭제할 때 발생하는 외래키 제약조건 문제 수정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/IdeaRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/IdeaRepository.java
@@ -78,4 +78,7 @@ public interface IdeaRepository extends JpaRepository<Idea, Long> {
             @Param("scheduleId") long scheduleId,
             @Param("status") IdeaStatus status
     );
+
+    @Query(value = "SELECT * FROM idea WHERE project_id = :projectId", nativeQuery = true)
+    List<Idea> findAllByProjectIdIncludeDeleted(@Param("projectId") long projectId);
 }


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

`TeamBuildingProject` 레코드를 삭제할 때, `Idea`의 `ProjectTopic` 외래키 제약조건으로 인해 캐스캐이드 삭제에 실패하는 문제를 해결했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.