### PR TITLE
refactor(activity): 기수 타입을 `Generation` enum으로 변경

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/activity/domain/Activity.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/activity/domain/Activity.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.activity.domain;
 
 import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,7 +18,7 @@ public class Activity extends BaseEntity {
 
     @Column(length = 5)
     private String speaker;
-    private String generation;  // TODO: Generation enum으로 바꾸기
+    private Generation generation;
     private String videoUrl;
     private String thumbnailUrl;
 
@@ -26,7 +27,7 @@ public class Activity extends BaseEntity {
     private ActivityCategory activityCategory;
 
     @Builder
-    public Activity(String title, String speaker, String generation,
+    public Activity(String title, String speaker, Generation generation,
                     String videoUrl, ActivityCategory activityCategory,
                     String thumbnailUrl) {
         this.title = title;
@@ -38,7 +39,7 @@ public class Activity extends BaseEntity {
     }
 
     public void update(String title, String speaker,
-                       String generation, String thumbnailUrl, String videoUrl) {
+                       Generation generation, String thumbnailUrl, String videoUrl) {
         this.title = title;
         this.speaker = speaker;
         this.generation = generation;

--- a/src/main/java/com/skhu/gdgocteambuildingproject/activity/model/ActivityInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/activity/model/ActivityInfoMapper.java
@@ -26,7 +26,7 @@ public class ActivityInfoMapper {
         return ActivityInfoResponseDto.builder()
                 .title(activity.getTitle())
                 .speaker(activity.getSpeaker())
-                .generation(activity.getGeneration())
+                .generation(activity.getGeneration().getLabel())
                 .videoUrl(activity.getVideoUrl())
                 .thumbnailUrl(activity.getThumbnailUrl())
                 .build();

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/ActivityMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/ActivityMapper.java
@@ -2,6 +2,7 @@ package com.skhu.gdgocteambuildingproject.admin.model;
 
 import com.skhu.gdgocteambuildingproject.admin.dto.activity.ActivityResponseDto;
 import com.skhu.gdgocteambuildingproject.activity.domain.Activity;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,7 +13,7 @@ public class ActivityMapper {
                 .categoryTitle(activity.getActivityCategory().getName())
                 .postTitle(activity.getTitle())
                 .postId(activity.getId())
-                .generation(activity.getGeneration())
+                .generation(activity.getGeneration().getLabel())
                 .speaker(activity.getSpeaker())
                 .videoUrl(activity.getVideoUrl())
                 .thumbnailUrl(activity.getThumbnailUrl())

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/PostInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/PostInfoMapper.java
@@ -11,7 +11,7 @@ public class PostInfoMapper {
                 .id(activity.getId())
                 .title(activity.getTitle())
                 .speaker(activity.getSpeaker())
-                .generation(activity.getGeneration())
+                .generation(activity.getGeneration().getLabel())
                 .thumbnailUrl(activity.getThumbnailUrl())
                 .videoUrl(activity.getVideoUrl())
                 .build();

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/service/AdminActivityServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/service/AdminActivityServiceImpl.java
@@ -10,6 +10,7 @@ import com.skhu.gdgocteambuildingproject.activity.domain.ActivityCategory;
 import com.skhu.gdgocteambuildingproject.activity.repository.ActivityCategoryRepository;
 import com.skhu.gdgocteambuildingproject.activity.repository.ActivityRepository;
 import com.skhu.gdgocteambuildingproject.global.exception.ExceptionMessage;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,7 @@ public class AdminActivityServiceImpl implements AdminActivityService {
         activity.update(
                 requestDto.title(),
                 requestDto.speaker(),
-                requestDto.generation(),
+                Generation.fromLabel(requestDto.generation()),
                 requestDto.thumbnailUrl(),
                 requestDto.videoUrl()
         );
@@ -126,7 +127,7 @@ public class AdminActivityServiceImpl implements AdminActivityService {
             Activity activity = Activity.builder()
                     .activityCategory(category)
                     .title(postDto.title())
-                    .generation(postDto.generation())
+                    .generation(Generation.fromLabel(postDto.generation()))
                     .speaker(postDto.speaker())
                     .videoUrl(postDto.videoUrl())
                     .thumbnailUrl(postDto.thumbnailUrl())


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

액티비티 엔티티에서 사용중인 기수 타입을 기존 `String`에서 `Generation` enum으로 변경하였습니다.

## 🔍 관련 이슈
- close #264 

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.

고치다 보니 관리자쪽 액티비티 관련 사항도 건드렸는데, 참고바랍니다.