### PR TITLE
refactor(activity): 기수 필드를 `String`에서 `Generation` enum으로 변경

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/ProjectGalleryInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/ProjectGalleryInfoMapper.java
@@ -11,7 +11,7 @@ public class ProjectGalleryInfoMapper {
                 .id(galleryProject.getId())
                 .projectName(galleryProject.getProjectName())
                 .serviceStatus(galleryProject.getServiceStatus())
-                .generation(galleryProject.getGeneration())
+                .generation(galleryProject.getGeneration().getLabel())
                 .createdAt(galleryProject.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/domain/GalleryProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/domain/GalleryProject.java
@@ -3,6 +3,7 @@ package com.skhu.gdgocteambuildingproject.projectgallery.domain;
 import com.skhu.gdgocteambuildingproject.global.entity.BaseEntity;
 import com.skhu.gdgocteambuildingproject.projectgallery.domain.enumtype.ServiceStatus;
 import com.skhu.gdgocteambuildingproject.user.domain.User;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,7 +33,8 @@ public class GalleryProject extends BaseEntity {
     @Column(nullable = false)
     private String projectName;
     @Column(nullable = false)
-    private String generation;
+    @Enumerated(EnumType.STRING)
+    private Generation generation;
     @Column(nullable = false)
     private String shortDescription;
 
@@ -56,7 +58,7 @@ public class GalleryProject extends BaseEntity {
 
     public void update(
             String projectName,
-            String generation,
+            Generation generation,
             String shortDescription,
             ServiceStatus serviceStatus,
             String description,

--- a/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/dto/project/res/GalleryProjectSummaryResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/dto/project/res/GalleryProjectSummaryResponseDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 @Builder
 public record GalleryProjectSummaryResponseDto(
         Long galleryProjectId,
+        String generation,
         String projectName,
         String shortDescription,
         String serviceStatus,

--- a/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/model/mapper/GalleryProjectInfoMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/model/mapper/GalleryProjectInfoMapper.java
@@ -20,7 +20,7 @@ public class GalleryProjectInfoMapper {
         return GalleryProjectInfoResponseDto.builder()
                 .galleryProjectId(project.getId())
                 .projectName(project.getProjectName())
-                .generation(project.getGeneration())
+                .generation(project.getGeneration().getLabel())
                 .shortDescription(project.getShortDescription())
                 .serviceStatus(project.getServiceStatus().name())
                 .description(project.getDescription())
@@ -33,6 +33,7 @@ public class GalleryProjectInfoMapper {
     public GalleryProjectSummaryResponseDto mapToSummary(GalleryProject project) {
         return GalleryProjectSummaryResponseDto.builder()
                 .galleryProjectId(project.getId())
+                .generation(project.getGeneration().getLabel())
                 .projectName(project.getProjectName())
                 .shortDescription(project.getShortDescription())
                 .serviceStatus(project.getServiceStatus().name())

--- a/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/service/GalleryProjectServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/service/GalleryProjectServiceImpl.java
@@ -18,6 +18,7 @@ import com.skhu.gdgocteambuildingproject.projectgallery.model.mapper.GalleryProj
 import com.skhu.gdgocteambuildingproject.projectgallery.repository.GalleryProjectMemberRepository;
 import com.skhu.gdgocteambuildingproject.projectgallery.repository.GalleryProjectRepository;
 import com.skhu.gdgocteambuildingproject.user.domain.User;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
 import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.AccessLevel;
@@ -85,7 +86,7 @@ public class GalleryProjectServiceImpl implements GalleryProjectService {
         GalleryProject galleryProject = findGalleryProjectById(projectId);
         galleryProject.update(
                 requestDto.projectName(),
-                requestDto.generation(),
+                Generation.fromLabel(requestDto.generation()),
                 requestDto.shortDescription(),
                 requestDto.serviceStatus(),
                 requestDto.description(),
@@ -145,7 +146,7 @@ public class GalleryProjectServiceImpl implements GalleryProjectService {
         return galleryProjectRepository.save(
                 GalleryProject.builder()
                         .projectName(requestDto.projectName())
-                        .generation(requestDto.generation())
+                        .generation(Generation.fromLabel(requestDto.generation()))
                         .shortDescription(requestDto.shortDescription())
                         .serviceStatus(requestDto.serviceStatus())
                         .description(requestDto.description())

--- a/src/test/java/com/skhu/gdgocteambuildingproject/projectgallery/model/GalleryProjectInfoMapperTest.java
+++ b/src/test/java/com/skhu/gdgocteambuildingproject/projectgallery/model/GalleryProjectInfoMapperTest.java
@@ -6,6 +6,7 @@ import com.skhu.gdgocteambuildingproject.projectgallery.dto.project.res.*;
 import com.skhu.gdgocteambuildingproject.projectgallery.model.mapper.GalleryProjectInfoMapper;
 import com.skhu.gdgocteambuildingproject.projectgallery.model.mapper.GalleryProjectMemberMapper;
 import com.skhu.gdgocteambuildingproject.user.domain.User;
+import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -52,7 +53,7 @@ class GalleryProjectInfoMapperTest {
 
         GalleryProject project = GalleryProject.builder()
                 .projectName(PROJECT_NAME)
-                .generation(GENERATION)
+                .generation(Generation.fromLabel(GENERATION))
                 .shortDescription(SHORT_DESC)
                 .serviceStatus(STATUS)
                 .description(DESCRIPTION)
@@ -90,6 +91,7 @@ class GalleryProjectInfoMapperTest {
 
         when(project.getId()).thenReturn(PROJECT_ID);
         when(project.getProjectName()).thenReturn(PROJECT_NAME);
+        when(project.getGeneration()).thenReturn(Generation.fromLabel(GENERATION));
         when(project.getShortDescription()).thenReturn(SHORT_DESC);
         when(project.getServiceStatus()).thenReturn(STATUS);
         when(project.getThumbnailUrl()).thenReturn(FILE_URL);
@@ -100,6 +102,7 @@ class GalleryProjectInfoMapperTest {
         // then
         assertThat(dto.galleryProjectId()).isEqualTo(PROJECT_ID);
         assertThat(dto.projectName()).isEqualTo(PROJECT_NAME);
+        assertThat(dto.generation()).isEqualTo(GENERATION);
         assertThat(dto.shortDescription()).isEqualTo(SHORT_DESC);
         assertThat(dto.serviceStatus()).isEqualTo(STATUS.name());
         assertThat(dto.thumbnailUrl()).isEqualTo(FILE_URL);


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

기수 필드를 `String`에서 `Generation` enum으로 변경하였습니다.
그에 따라 dto와 테스트 코드 또한 수정하였습니다.

## 🔍 관련 이슈
- close #266 

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.