### PR TITLE
fix(ci): 배포 시 컨테이너 이름 충돌로 인한 compose 실패 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,11 +163,14 @@ jobs:
             # 5) tbs-network가 없으면 생성
             docker network create tbs-network || true
             
-            # 6) docker compose로 전체 서비스 재기동
+            # 6) 기존 컨테이너 제거
+            docker rm -f teamBuildingSystem-app tbs-redis || true
+            
+            # 7) docker compose로 전체 서비스 재기동
             docker compose down || true
             docker compose up -d
             
-            # 7) 컨테이너 상태/로그 확인
+            # 8) 컨테이너 상태/로그 확인
             sleep 2
             docker compose ps
             docker logs --tail=100 teamBuildingSystem-app || true


### PR DESCRIPTION
## 📝 PR 설명
배포 시 컨테이너 이름 충돌로 인한 compose 실패 문제를 해결했습니다.

## 🔍 관련 이슈
- #226

## ✅ TODO
- [ ] 기존에 존재하던 컨테이너를 삭제하고 다시 새로운 컨테이너를 올리도록 수정

## 기타