### PR TITLE
fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/Idea.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/Idea.java
@@ -172,7 +172,7 @@ public class Idea extends BaseEntity {
         this.registerStatus = IdeaStatus.REGISTERED;
     }
 
-    public void delete() {
+    public void markAsDeleted() {
         deleted = true;
     }
 

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -55,6 +55,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -70,6 +71,7 @@ public class IdeaServiceImpl implements IdeaService {
     private final TeamBuildingProjectRepository projectRepository;
     private final UserRepository userRepository;
     private final IdeaEnrollmentRepository ideaEnrollmentRepository;
+    private final EntityManager entityManager;
 
     private final ProjectUtil projectUtil;
     private final ParticipationUtil participationUtil;
@@ -306,8 +308,9 @@ public class IdeaServiceImpl implements IdeaService {
         // 소프트 딜리트를 사용하므로 명시적으로 제거
         ideaMemberRepository.deleteAll(idea.getMembers());
         ideaEnrollmentRepository.deleteAll(idea.getEnrollments());
+        entityManager.flush();
 
-        idea.delete();
+        idea.markAsDeleted();
     }
 
     @Override


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

엔티티 매니저를 사용해 `flush`하여 강제로 delete 명령을 실행합니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.