### PR TITLE
feat(team building): '수락 예정'인 멤버 삭제 시 '거절 예정'으로 전이하도록 개선

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -344,7 +344,7 @@ public class IdeaServiceImpl implements IdeaService {
         // 수락 예정인 멤버면 스케줄러가 무시하도록 상태 변경
         IdeaEnrollment enrollment = idea.findScheduleToAcceptEnrollmentOf(member)
                 .orElseThrow(() -> new IllegalStateException(NOT_MEMBER_OF_IDEA.getMessage()));
-        enrollment.accept();
+        enrollment.scheduleToReject();
     }
 
     @Override
@@ -376,8 +376,7 @@ public class IdeaServiceImpl implements IdeaService {
 
         validateMemberDeletable(enrollment);
 
-        // '수락' 상태로 강제해서 스케줄러가 무시하도록 한다.
-        enrollment.accept();
+        enrollment.scheduleToReject();
     }
 
     private ProjectSchedule findCurrentSchedule() {


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

기존엔 '수락 예정'인 멤버를 삭제할 때 '수락' 상태로 전이하여 스케줄러가 멤버로 등록하지 않게 했습니다.
기획에 따라 '거절 예정'으로 전이하도록 수정했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.