### PR TITLE
feat(team building): 받은 지원 조회 내역 API가 Enum 타입을 적절한 형태로 응답하도록 개선 

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/EnrollmentStatus.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/enumtype/EnrollmentStatus.java
@@ -17,11 +17,19 @@ public enum EnrollmentStatus {
         this.waitingToConfirm = waitingToConfirm;
     }
 
-    public EnrollmentStatus confirmedStatus() {
+    public EnrollmentStatus forCreator() {
         return switch (this) {
             case SCHEDULED_TO_ACCEPT -> ACCEPTED;
             case SCHEDULED_TO_REJECT -> REJECTED;
             default -> this;
         };
+    }
+
+    public EnrollmentStatus forApplicant() {
+        if (isWaitingToConfirm()) {
+            return WAITING;
+        }
+
+        return this;
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/ReceivedEnrollmentMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/ReceivedEnrollmentMapper.java
@@ -16,7 +16,7 @@ public class ReceivedEnrollmentMapper {
         return ReceivedEnrollmentResponseDto.builder()
                 .enrollmentId(enrollment.getId())
                 .choice(enrollment.getChoice())
-                .enrollmentStatus(enrollment.getStatus().confirmedStatus())
+                .enrollmentStatus(enrollment.getStatus().forCreator())
                 .enrollmentAcceptable(idea.isEnrollmentAvailable(part))
                 .applicantId(applicant.getId())
                 .applicantName(applicant.getName())

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/SentEnrollmentMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/SentEnrollmentMapper.java
@@ -2,7 +2,6 @@ package com.skhu.gdgocteambuildingproject.teambuilding.model.mapper;
 
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.Idea;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.IdeaEnrollment;
-import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.EnrollmentStatus;
 import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.enrollment.SentEnrollmentResponseDto;
@@ -26,7 +25,7 @@ public class SentEnrollmentMapper {
         return SentEnrollmentResponseDto.builder()
                 .enrollmentId(enrollment.getId())
                 .choice(enrollment.getChoice())
-                .enrollmentStatus(convertToProperStatus(enrollment.getStatus()))
+                .enrollmentStatus(enrollment.getStatus().forApplicant())
                 .ideaTitle(idea.getTitle())
                 .ideaIntroduction(idea.getIntroduction())
                 .enrollmentPart(enrollmentPart)
@@ -48,13 +47,5 @@ public class SentEnrollmentMapper {
         return (int) idea.getEnrollmentsOf(schedule).stream()
                 .filter(enrollment -> enrollment.getPart() == part)
                 .count();
-    }
-
-    private EnrollmentStatus convertToProperStatus(EnrollmentStatus status) {
-        if (status.isWaitingToConfirm()) {
-            return EnrollmentStatus.WAITING;
-        }
-
-        return status;
     }
 }


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

본인이 받은 지원 내역을 조회할 때, '수락 예정', '거절 예정' 상태를 각각 '수락', '거절' 상태로 보이도록 개선했습니다.
용도별로 상태를 처리하는 로직을 `EnrollmentStatus` 스스로가 책임지도록 리팩터링했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.