### PR TITLE
refactor(project gallery): db에 저장되는 설명 컬럼의 길이를 `LONGTEXT`로 명시

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/domain/GalleryProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/domain/GalleryProject.java
@@ -43,7 +43,7 @@ public class GalleryProject extends BaseEntity {
     private ServiceStatus serviceStatus;
 
     @Lob
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String description;
 
     private String thumbnailUrl; // null일 결우 프론트에서 기본이미지 처리


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

db에 설명 컬럼이 저장될 때, `VARCHAR`로도 받지 못하는 길이를 입력받게 되었을 때에 발생하는 `Data truncation`으로 인한 오류를 방지하였습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.