### PR TITLE
hotfix(auth): 리프레시 토큰 로테이션 및 액세스 토큰 재발급 버그 해결

### DIFF
--- a/actional
+++ b/actional
@@ -1,0 +1,6007 @@
+[33mcommit b9139944663db154c695f44bc546efdb4a21282b[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mhotfix/#341[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 15 02:59:40 2025 +0900
+
+    fix
+
+[33mcommit 0a6263f0314957a5a40ed36895d63e0f7bbbbc37[m[33m ([m[1;31morigin/hotfix/#341[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 15 02:40:07 2025 +0900
+
+    hotfix: refresh token 만료 정책을 환경변수 기반으로 정리
+
+[33mcommit f457386e5bb9fa5136f689c1da8c27f1069d9848[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m, [m[1;32mmain[m[33m)[m
+Merge: c92991a 09c6a61
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Mon Dec 15 01:34:45 2025 +0900
+
+    hotfix: token에서 refreshToken으로 이름 수정
+    
+    hotfix: token에서 refreshToken으로 이름 수정
+
+[33mcommit 09c6a614ea235d23b8e89244b497387dde14127a[m[33m ([m[1;31morigin/hotfix/#339[m[33m, [m[1;32mhotfix/#339[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 15 01:32:30 2025 +0900
+
+    hotfix: token에서 refreshToken으로 이름 수정
+
+[33mcommit c92991acc044473c7529c2c02ae5ecfbf98bfb52[m
+Merge: b7ecba7 4083c26
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Mon Dec 15 01:20:59 2025 +0900
+
+    hotfix: 만료된 리프레쉬 토큰 스케줄러 이용하여 제거
+    
+    hotfix: 만료된 리프레쉬 토큰 제거
+
+[33mcommit 4083c2699a101d4694410fef0e2ce79f3e8f13be[m[33m ([m[1;31morigin/hotfix/#334[m[33m, [m[1;32mhotfix/#334[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 15 01:06:23 2025 +0900
+
+    refactor: 스케줄러 이용하여 만료된 리프레쉬 토큰 제거
+
+[33mcommit b7ecba7854c5f894d2f4f910bf5965e7e7b78dbb[m
+Merge: adab209 86cd617
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Mon Dec 15 00:26:54 2025 +0900
+
+    Merge pull request #337 from ggok0265/main
+    
+    fix(project gallery): 팀장은 해당 프로젝트의 전시 여부에 상관없이 상세조회 가능하도록 수정
+
+[33mcommit 86cd617319b17dd4b3bc84c78908869ea60ea154[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Mon Dec 15 00:22:46 2025 +0900
+
+    fix(project gallery): 팀장은 해당 프로젝트의 전시 여부에 상관없이 상세조회 가능하도록 수정
+
+[33mcommit 45e3207482a84ec07dbee78193b092f4ceb68766[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Mon Dec 15 00:12:45 2025 +0900
+
+    fix(project gallery): 팀원이 없는 프로젝트 생성 가능하도록 수정
+
+[33mcommit adab2096e925c0c36a8d9f19d0d4703261c8f076[m
+Merge: bb47000 e4a432d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Dec 15 00:11:14 2025 +0900
+
+    Merge pull request #336 from kjoon418/main
+    
+    fix(security): 부적절한 JWT를 통해 요청할 때 500 에러를 응답하던 문제 수정
+
+[33mcommit e4a432dfcc8212e0b45063cfa4510a4d760f0fa3[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 15 00:10:34 2025 +0900
+
+    chore(security): 과한 주석 수정
+
+[33mcommit 6df1e6f773423d545bbecb5451e53a4faa90beaf[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 15 00:08:43 2025 +0900
+
+    fix(security): 부적절한 JWT를 통해 요청할 때 500 에러를 응답하던 문제 수정
+
+[33mcommit d94fddfd6de95213f448ad725507e69cf7b5fcd0[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 14 23:15:44 2025 +0900
+
+    hotfix: 만료된 리프레쉬 토큰 제거
+
+[33mcommit bb47000058c0862f34ac912f10ac21e7bb389fbd[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 21:41:44 2025 +0900
+
+    fix(mypage): GalleryProject 엔티티 객체의 필드 이름 충돌 해결
+
+[33mcommit 5ec15580105d2f72e0c9d1d669ae8b0ebeecf3e9[m
+Merge: 8f352cb bc461ad
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sun Dec 14 21:35:11 2025 +0900
+
+    Merge pull request #332 from TwooTwoo/feat#311-userProjectList
+    
+    feat(mypage): 프로젝트 전시 여부 토글 기능 구현 + 마이페이지 프로젝트 응답 구조 개선
+
+[33mcommit bc461ad43699820dfde30ce7da145f1814f5634d[m
+Merge: d0aca3a 8f352cb
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sun Dec 14 21:35:05 2025 +0900
+
+    Merge branch 'main' into feat#311-userProjectList
+
+[33mcommit d0aca3aa8678107fa59dca7ff4d58e0e7e246e50[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 21:33:01 2025 +0900
+
+    feat: 프로젝트 전시 여부 수정 기능 추가 및 권한 검증/예외 처리 개선
+
+[33mcommit a66801ce0ff771b2e91b09a9afe1c1eda79c0fa9[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 21:09:58 2025 +0900
+
+    fix(mypage): 마이페이지에서 내 프로젝트 목록 조회시 응답하는 값을 프론트엔드의 요구사항에 맞게 변경
+
+[33mcommit 8f352cb7bd8ae1952f0a26705eb05d8833c15586[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 18:50:23 2025 +0900
+
+    fix(project gallery): 프젝갤 로직에서 exhibited 칼럼을 인식하도록 수정
+
+[33mcommit cdb290dfb8e934ea2aba58c8ce136fc61cd9c305[m
+Merge: 2f17c6a be2d540
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 18:43:42 2025 +0900
+
+    Merge branch 'main' of github.com:GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System
+
+[33mcommit 2f17c6aa9985c50c6531efae65a98066be0ee4f7[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 18:42:36 2025 +0900
+
+    fix(project gallery): GalleryProject.exhibited를 JPA가 인식하도록 수정, is_exhibited 칼럼에 매핑되도록 수정
+
+[33mcommit be2d540a116921f22664822fa1fb144ae52efd95[m
+Merge: 5075015 3362b5b
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sun Dec 14 17:49:43 2025 +0900
+
+    Merge pull request #330 from TwooTwoo/feat#311-userProjectList
+    
+    feat(mypage): 로그인한 사용자 본인이 참여한 프젝갤 프로젝트 리스트 조회 기능 구현
+
+[33mcommit 3362b5b213ed81e114f280f13429573ea7a1943f[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 17:39:29 2025 +0900
+
+    docs(mypage): 스웨거 문서에 기입된 설명에 개행을 추가해 가독성 향상
+
+[33mcommit dcfd3498f8276b998cff46f6c13deb3c6831ce60[m
+Merge: 84b2f9f 5075015
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sun Dec 14 11:52:47 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into feat#311-userProjectList
+
+[33mcommit 84b2f9f041df464aee4e7199967923902229a94a[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 14 11:52:08 2025 +0900
+
+    feat(mypage): 로그인한 사용자가 참여한 프젝갤 프로젝트 목록 조회 기능 구현
+
+[33mcommit 50750156d1a695c62b26ef9e3aef59357489f7dc[m
+Merge: 1513afe b024fcd
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Dec 13 23:28:38 2025 +0900
+
+    Merge pull request #329 from ggok0265/main
+    
+    refactor(project gallery): 프로젝트 정보 및 생성/수정 시에 필요한 필드 추가
+
+[33mcommit b024fcd6f46fe598b19dbe25a7a155c30fccca25[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 23:20:23 2025 +0900
+
+    feat(project gallery): 프로젝트 등록 시에 필요한 정보를 반환하는 기능 구현
+
+[33mcommit ccd94668c044d88964edf55650322f19088f1f95[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 23:05:28 2025 +0900
+
+    refactor(project gallery): 프로젝트 정보 및 생성/수정 시에 필요한 필드 추가
+
+[33mcommit 1513afe4e71dc1ee4fcc62265f9d92ae4ba4f318[m
+Merge: 25d05ae 8188a53
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 23:06:57 2025 +0900
+
+    Merge pull request #328 from kjoon418/main
+    
+    feat(team building): ID 기반 프로젝트 정보 조회 API 구현
+
+[33mcommit 8188a53871a995852bd291fe46d8f4d0af0b6090[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 23:05:28 2025 +0900
+
+    feat(team building): ID 기반 프로젝트 정보 조회 API 구현
+
+[33mcommit 25d05ae1bc9d710a7eabdec1996650ab5eb8d287[m
+Merge: f70f14b fa40cd7
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 22:53:27 2025 +0900
+
+    Merge pull request #327 from kjoon418/main
+    
+    feat(team building): 관리자는 프로젝트 참여 여부 검증을 건너뛰도록 개선
+
+[33mcommit fa40cd7f7b3c9eecd8e1300e22d7e14386b1d9d1[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 22:52:10 2025 +0900
+
+    feat(team building): 관리자는 프로젝트 참여 여부 검증을 건너뛰도록 개선
+
+[33mcommit f70f14b2ae9f6be5ff0daa640d2026c8c447b54b[m
+Merge: c3771aa 19c0bb3
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 22:31:19 2025 +0900
+
+    Merge pull request #326 from kjoon418/main
+    
+    feat(team building): 프로젝트 이름 수정을 별도의 API로 분리
+
+[33mcommit 19c0bb313d269b4fbb63a7559608ee26fd3d4491[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 22:31:08 2025 +0900
+
+    feat(team building): Part 목록 조회 API 구현
+
+[33mcommit 92660d2900c5d6eb9fb9527b7b8f28beb7c36006[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 22:24:50 2025 +0900
+
+    feat(team building): 프로젝트 이름 수정을 별도의 API로 분리
+
+[33mcommit c3771aa279148bfbde00c470c6e5887a7a57861b[m
+Merge: cc5fb7e aa81941
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sat Dec 13 22:17:18 2025 +0900
+
+    Merge pull request #325 from GDG-on-Campus-SKHU/feature/#323
+    
+    feat(adminProjectGallery) : 프로젝트 갤러리 상세 정보 조회 API
+
+[33mcommit aa81941eee72f5910045af9a51a8affd36cbb4bc[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 22:13:49 2025 +0900
+
+    refactor(adminProjectGallery) : 안쓰는 import문 제거
+
+[33mcommit 7d904e46480a0b16ec610446ceb4090a038142fe[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 22:13:24 2025 +0900
+
+    feat(adminProjectGallery) : 프로젝트 갤러리 상세 조회에 회원 정보용 dto 클래스 추가
+
+[33mcommit 1d2c376a223c56c40fdee24bdbce2ce23fa8b333[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 22:13:10 2025 +0900
+
+    feat(adminProjectGallery) : 프로젝트 갤러리 상세 조회에 회원 정보용 mapper 클래스 추가
+
+[33mcommit ed160698fcba958963e0d4d621a9bd4ccf628c5e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 22:11:45 2025 +0900
+
+    feat(adminProjectGallery) : 서비스 레이어에 프로젝트 갤러리 상세 조회 API 구현
+
+[33mcommit 1bee059e4af46871b9bc8ba618eb4b261c551a81[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 22:11:26 2025 +0900
+
+    feat(adminProjectGallery) : 프로젝트 갤러리 상세 조회 API 구현
+
+[33mcommit f816d75face5de9c7a298a969872801f6a24d995[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 22:11:12 2025 +0900
+
+    feat(adminProjectGallery) : 수정 API에 쓰일 랜더링 프로젝트 갤러리 상세 조회 API 구현
+
+[33mcommit cc5fb7eeba2af511ebdda33c84185d33baa2f398[m
+Merge: edbe4c5 86326ba
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 22:04:34 2025 +0900
+
+    Merge pull request #324 from kjoon418/main
+    
+    feat(team building): 지원 내역 조회 가능 여부 조회 API 구현
+
+[33mcommit 86326bad88631e433db502aaa5789d41b8a16c3c[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 22:03:26 2025 +0900
+
+    feat(team building): 지원 내역 조회 가능 여부 조회 API 구현
+
+[33mcommit edbe4c5ca4f6896a0d96a2dd894092cd824ff145[m
+Merge: f038845 14924d6
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Dec 13 18:28:47 2025 +0900
+
+    refactor: 예외처리 조건 수정
+    
+    fix: 예외처리 조건 수정
+
+[33mcommit 14924d689aadc68563a8e2ac4273a03544f7be34[m[33m ([m[1;31morigin/refactor/#321[m[33m, [m[1;32mrefactor/#321[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 17:55:59 2025 +0900
+
+    fix: GlobalExceptionHandler JSON 파싱에 실패했습니다. 로 변경
+
+[33mcommit f0388456da84126fc1211c17149772e9a897f695[m
+Merge: e27ce90 8ba20ce
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Dec 13 16:50:17 2025 +0900
+
+    Merge pull request #320 from TwooTwoo/fix/#319/profile
+    
+    fix(profile): 프로필 수정시 기술스택과 유저링크가 수정되지 않던 문제 해결
+
+[33mcommit 8ba20ce94319e941f2ae31319a4fd368493a4b0a[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 13 16:40:27 2025 +0900
+
+    refactor(profile): 관리자 페이지에서 특정 회원의 프로필을 수정할 때 requestbody에서 iconUrl을 받지 않도록 수정
+
+[33mcommit 7990c618bceb810582fcdfaa0f6e3c07156fcefe[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 13 16:34:01 2025 +0900
+
+    refactor(profile): 관리자 페이지에서 특정 회원의 프로필을 수정할 때 requestbody에서 iconUrl을 받지 않도록 수정
+
+[33mcommit e0229d8d6414aeb765c873c0d46f275626edaa0b[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 13 16:03:32 2025 +0900
+
+    fix(profile): User 객체의 기술스택, 유저링크 필드에 cascade와 orphanRemoval 설정
+
+[33mcommit e27ce9001954b57d11c086f7b36793fdc240e1c3[m
+Merge: 609a413 356ebd8
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 15:32:44 2025 +0900
+
+    Merge pull request #318 from kjoon418/main
+    
+    feat(team building): 지원 내역 조회 API 개선
+
+[33mcommit 356ebd8b1859a96be7427a1278325ee46b5317c9[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 15:30:10 2025 +0900
+
+    feat(team building): 받은 지원 현황 조회 API가 일정 마감 여부도 응답하도록 개선
+
+[33mcommit 683554bd41daf0fbe5be0c4724c881574563af0f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 15:23:35 2025 +0900
+
+    refactor(team building): 본인의 지원 내역 조회 API의 응답 형태 리팩터링
+
+[33mcommit 609a41330f7f0cd9bae7b582bfaf9f0d325347b8[m
+Merge: 0e34303 a02ca06
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 15:10:54 2025 +0900
+
+    Merge pull request #317 from kjoon418/main
+    
+    feat(team building): 받은 지원 조회 내역 API가 Enum 타입을 적절한 형태로 응답하도록 개선
+
+[33mcommit a02ca06af4376048a95cb54fbfa4bbf4e8a947a8[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 15:08:59 2025 +0900
+
+    refactor(team building): `EnrollmentStatus`가 용도별 응답값을 스스로 책임지도록 리팩터링
+
+[33mcommit 7f387287ab1b68778398fa3f01b78d5060d18f32[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 15:04:48 2025 +0900
+
+    feat(team building): 받은 지원 조획 내역 API가 Enum 타입을 적절한 형태로 응답하도록 개선
+
+[33mcommit 0e34303a52282a1ceb3dd751ff89c49aa5e5ed96[m
+Merge: 3b0412b 9b126ba
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 14:56:35 2025 +0900
+
+    Merge pull request #316 from kjoon418/main
+    
+    feat(team building): 지원 중복 검증 로직 개선
+
+[33mcommit 9b126bab951e1a10e615f2b88d432e7432032b10[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 14:55:37 2025 +0900
+
+    feat(team building): 지원 중복 검증 로직 개선
+
+[33mcommit 3b0412bd5e91468371847fea8228d2b302353c07[m
+Merge: c045a14 1b968ed
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 14:48:58 2025 +0900
+
+    Merge pull request #315 from kjoon418/main
+    
+    feat(team building): '수락 예정'인 멤버 삭제 시 '거절 예정'으로 전이하도록 개선
+
+[33mcommit 1b968ed9845aae458d7b505fbdedf32d24559dcb[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 14:47:28 2025 +0900
+
+    feat(team building): '수락 예정'인 멤버 삭제 시 '거절 예정'으로 전이하도록 개선
+
+[33mcommit c045a14a0bb702d85a3035bb8ef1d3fe028e5e1d[m
+Merge: 0c0c17a 60e8ffc
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 14:27:14 2025 +0900
+
+    Merge pull request #314 from kjoon418/main
+    
+    feat(team building): 아이디어 임시저장 기능 개선
+
+[33mcommit 60e8ffc1cd0af86214f31d26053c2a8ece61399e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 14:25:39 2025 +0900
+
+    feat(team building): 임시 저장 시에는 아이디어 주제를 검증하지 않도록 개선
+
+[33mcommit ddce27b70d24f6323c8b06634b43cdd4266d4371[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 14:10:24 2025 +0900
+
+    feat(team building): 아이디어 등록 API가 아이디어 임시 저장 시각도 같이 응답하도록 개선
+
+[33mcommit 0c0c17a12255e8506edaa47fad34a1979f007cb5[m
+Merge: 9e84c61 6b43e86
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 14:03:43 2025 +0900
+
+    Merge pull request #313 from kjoon418/main
+    
+    feat(team building): Idea에 마지막으로 임시 저장된 시각에 대한 정보 추가
+
+[33mcommit 6b43e86a44f90e75a654cdf385449057688f6855[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 14:02:03 2025 +0900
+
+    feat(team building): `Idea`에 마지막으로 임시 저장된 시각에 대한 정보 추가
+
+[33mcommit 99262a1e5fec3230c074a9154909c307c0215add[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 13:57:55 2025 +0900
+
+    test(team building): 테스트 코드 변경 누락 수정
+
+[33mcommit 9e84c61320d9d3d2fc3a7aa36cb2b6c296a36c31[m
+Merge: 2e8059f 74da925
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 13:41:44 2025 +0900
+
+    Merge pull request #312 from kjoon418/main
+    
+    feat(team building): 아이디어 목록 조회 API에서 `topic` 필터링 기능 추가
+
+[33mcommit 74da925887e9710fc9b9f925c3255ac101a779a0[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 13:40:08 2025 +0900
+
+    feat(team building): 아이디어 목록 조회 API에서 `topic` 필터링 기능 추가
+
+[33mcommit 2e8059fdb7cfda4ee8554106e498169b54826464[m
+Merge: 97e9ac2 1966e64
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sat Dec 13 13:17:35 2025 +0900
+
+    Merge pull request #307 from GDG-on-Campus-SKHU/feature/#298
+    
+    feat(adminActivity) : 프로젝트 갤러리 목록 반환 API 구현
+
+[33mcommit 97e9ac2afcf814a4d5eeb93935a39743b66fd65c[m
+Merge: 337396b 64292a1
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Dec 13 11:06:50 2025 +0900
+
+    hotfix: Enumtype 예외처리 기능 구현
+    
+    Enumtype 예외처리 기능 구현
+
+[33mcommit 64292a1089a5ad7183b67f79673689b17d9c6e9f[m[33m ([m[1;31morigin/hotfix/#309[m[33m, [m[1;32mhotfix/#309[m[33m)[m
+Merge: fa70878 337396b
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 11:03:34 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into hotfix/#309
+
+[33mcommit fa70878e60b59789f175bbed450c8da1461c91b5[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 11:03:14 2025 +0900
+
+    hotfix: Position, Role, BANNED 예외처리
+
+[33mcommit 337396b5bd25c839f6b0aac911ebd706fec29b69[m
+Merge: 0f4a97e d84830e
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Dec 13 10:00:54 2025 +0900
+
+    refactor: 인증/인가, email api 버그 수정
+    
+    refactor: 인증/인가, email api 버그 수정
+
+[33mcommit d84830e6692871b14c62d4198b5de4c03b7b08e0[m[33m ([m[1;31morigin/refactor/#306[m[33m, [m[1;32mrefactor/#306[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 09:57:34 2025 +0900
+
+    fix: User 회원탈퇴 기능 버그 수정
+
+[33mcommit a2dc51e6c013667da56aa77f3386e114a50d4bbf[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 05:51:38 2025 +0900
+
+    refactor: EmailControllerApi 분리 및 API 문서 정의
+
+[33mcommit 6d7fc4b57bcdd82d80a2259b5871a0c6ff7682ff[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 05:48:15 2025 +0900
+
+    hotfix: Email 인증번호 만료 버그 수정
+
+[33mcommit 7db344b7c45677f29e8594e6e4dc5e9b55cbfeb5[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 05:17:56 2025 +0900
+
+    refactor: Email Swagger 문서 설명 추가
+
+[33mcommit c8451ba50ee769bb7ce258a1248f5ac1ae2ceeba[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 05:13:34 2025 +0900
+
+    refactor: refresh 토큰 쿠키로 넘기기
+
+[33mcommit 02a1442ddb78ff99e138073dc5d623666ed2c4e4[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 04:37:38 2025 +0900
+
+    refactor: AuthController와 AuthControllerApi api 나누기
+
+[33mcommit 1966e6445cbf59f606ca7ef4b56e5cbc32e1f797[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 03:53:03 2025 +0900
+
+    refactor(adminProjectGallery) : GalleryProject에 추가된 필드에 따라 맵퍼 및 dto 클래스 리펙토링 진행
+
+[33mcommit 7400d8128b157e7907a5aab879d1f511e402c250[m
+Merge: 1a76cb3 0f4a97e
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 03:26:39 2025 +0900
+
+    Merge branch 'main' into feature/#298
+
+[33mcommit 1a76cb39420fe9d1f154757e1803ba3635f11863[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 03:21:54 2025 +0900
+
+    feat(adminProjectGallery) : 서비스 레이어에서 프로젝트 목록 반환 메서드 추가
+
+[33mcommit cb911ec364b882c147133a1908f875c8324c2023[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 03:21:17 2025 +0900
+
+    refactor(adminProjectGallery) : 프로젝트 갤러리 반환 API 추가 및 searchProjectGallery에서 url 수정
+
+[33mcommit 752c8d0b0821a66800ad3152bdbde7fda84dda0b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 03:19:43 2025 +0900
+
+    refactor(adminProjectGallery) : 프로젝트 갤러리에서 목록 조회 스웨거 문서 추가
+
+[33mcommit 0f4a97eb0ad5828783f82dd836550b8248a60e30[m
+Merge: 633c73f 0c20532
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Dec 13 03:12:04 2025 +0900
+
+    Merge pull request #305 from ggok0265/main
+    
+    fix(project gallery): jpa에서 잘못 매핑되고 있는 필드명 수정
+
+[33mcommit 0c205324f0df8e1a99cfbe3e5561a51bd599532a[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 03:11:04 2025 +0900
+
+    fix(project gallery): jpa에서 잘못 매핑되고 있는 필드명 수정
+
+[33mcommit 633c73f59ef06b95a79d016746ff10a0724c0530[m
+Merge: a8912ad 4743157
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Dec 13 02:52:57 2025 +0900
+
+    Merge pull request #303 from ggok0265/main
+    
+    feat(project gallery): 프로젝트 전시 여부 필드 추가
+
+[33mcommit 4743157d5cd55156af1cf08b67574a27a4ec3bb2[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 02:47:06 2025 +0900
+
+    feat(project gallery): 프로젝트 전시 여부 필드 추가
+
+[33mcommit a8912ad812ba06e97690476d9b1920a5d9f872b0[m
+Merge: d41404c cd92756
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Dec 13 02:43:11 2025 +0900
+
+    fix: 회원가입 버그 발생 수정
+    
+    fix: 회원가입 버그 발생 수정
+
+[33mcommit cd927568602c768f69753e359085f22ddff45391[m[33m ([m[1;31morigin/fix/#301[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 02:38:01 2025 +0900
+
+    chore: UserPosition, UserRole에 @JsonCreator 추가
+
+[33mcommit 04166fcd71732e54eca5643d92cf023f2e4c128e[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 02:33:34 2025 +0900
+
+    chore: Auth Swagger 문서 ROLE_로 수정
+
+[33mcommit 617d17b0f72c7898198dfc7e60c9bfd26091da07[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 02:14:10 2025 +0900
+
+    chore(project gallery): 프로젝트 삭제 API 비활성화
+
+[33mcommit d41404c6671baa40b5a6b37f2891a6e254d4682b[m[33m ([m[1;32mhotfix/#287[m[33m)[m
+Merge: 904dffe 2266e63
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Dec 13 02:10:56 2025 +0900
+
+    Merge pull request #299 from ggok0265/main
+    
+    fix(project gallery): 멤버 검색시 누락된 userId 필드 추가
+
+[33mcommit 2266e630aab5f3b3fc2450012672fceb3fedca69[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 01:59:56 2025 +0900
+
+    fix(project gallery): 멤버 검색시 누락된 userId 필드 추가
+
+[33mcommit 904dffed25dd7da02808ed295de26ad549304c45[m
+Merge: fe05e7d 03d776e
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Dec 13 02:06:34 2025 +0900
+
+    Merge pull request #300 from TwooTwoo/auth-enhancement-ktw
+    
+    fix(Auth): 보민이가 변경한 코드와의 충돌 해결
+
+[33mcommit fe05e7def4d1d873ce14b2c455439491802ba987[m
+Merge: 16e6196 2c23953
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Dec 13 02:05:27 2025 +0900
+
+    hotfix: 회원가입 버그 수정(인증/인가)
+    
+    hotfix: 회원가입 버그 수정(인증/인가)
+
+[33mcommit 03d776ec2b8b0f1ad72568eeec6ec25176f4888a[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 13 02:04:13 2025 +0900
+
+    fix(Auth): 보민이가 변경한 코드와의 충돌 해결
+
+[33mcommit 2c23953efbebf8b5b23da484068b9b5bdb1aa104[m[33m ([m[1;31morigin/hotfix/#287[m[33m)[m
+Merge: 23324c2 16e6196
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 02:03:26 2025 +0900
+
+    chore: main파일 충돌 제거(UserRole 수정)
+
+[33mcommit 16e61967d8f29eeaae89a6cd4b42ee0a0cf4ca5a[m
+Merge: bd8e95e dd287b5
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Dec 13 01:52:14 2025 +0900
+
+    Merge pull request #296 from TwooTwoo/auth-enhancement-ktw
+    
+    refactor(UserRole): @PreAuthorize의 hasRole 규칙에 맞게 ROLE_prefix 적용
+
+[33mcommit dd287b5096f84cbb0156164f09b5c8acdb166373[m
+Merge: cfccfe9 bd8e95e
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Dec 13 01:52:07 2025 +0900
+
+    Merge branch 'main' into auth-enhancement-ktw
+
+[33mcommit bd8e95eb15a84e0d8db3673ec95cbd9eee13d9b9[m
+Merge: 78c0fcd bc1064a
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 01:50:13 2025 +0900
+
+    Merge pull request #297 from kjoon418/main
+    
+    fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결
+
+[33mcommit bc1064a648b81df82d69b808d4069126ad111584[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 01:48:56 2025 +0900
+
+    fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결
+
+[33mcommit 23324c2d752fd6fd0b771111c3cec2ac0905c725[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 01:45:22 2025 +0900
+
+    chore: Part 예외처리 추가
+
+[33mcommit cfccfe9d5607ba969aa093b3c30c57d1c61c6e1d[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 13 01:45:18 2025 +0900
+
+    refactor(UserRole): @PreAuthorize의 hasRole 규칙에 맞게 ROLE_prefix 적용
+
+[33mcommit 833948460956464614953aa702169580eca562ec[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 01:40:59 2025 +0900
+
+    chore: email dto 제약조건 추가
+
+[33mcommit 78c0fcdac74cf96e328a4f3e0d29c26674c310c4[m
+Merge: 5bff1ae 66c1939
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 01:36:29 2025 +0900
+
+    Merge pull request #292 from kjoon418/main
+    
+    fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결
+
+[33mcommit 66c193959895b21df4101258e5bc7150ad87c70d[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 01:34:54 2025 +0900
+
+    fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결
+
+[33mcommit 6722ce5c4902666227c255277403aeecb36c334d[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 01:29:24 2025 +0900
+
+    feat: UserPosition, UserRole 예외처리 추가
+
+[33mcommit 5bff1ae415ba0d6af50beee27c8e90994dd8ef64[m
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Dec 13 01:29:10 2025 +0900
+
+    chore: 스웨거의 servers 목록에서 배포서버가 먼저 오도록 수정
+
+[33mcommit 52506d3c37b55e0419824c847fd9a5e6346c7bf8[m
+Merge: df9f009 30d5418
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Dec 13 01:21:26 2025 +0900
+
+    Merge pull request #291 from ggok0265/main
+    
+    feat(user): 토큰을 통한 userId값 반환 API 구현
+
+[33mcommit df9f009f5267043be2c22f6307fb7efa3c1a60a0[m
+Merge: 46a3ff5 318f9cb
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 01:19:12 2025 +0900
+
+    Merge pull request #289 from kjoon418/main
+    
+    fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결
+
+[33mcommit 318f9cb3a8a055380e05f5a6fc0637e5ff64f5cc[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 01:18:06 2025 +0900
+
+    fix(admin): 아이디어 하드 딜리트 API가, 소프트 딜리트 필터에 의해 엔티티를 삭제하지 못하던 문제 해결
+
+[33mcommit 30d5418a459776f876fb7ccee2f59a7cb8d595d4[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sat Dec 13 01:18:04 2025 +0900
+
+    feat(user): 토큰을 통한 userId값 반환 API 구현
+
+[33mcommit 46a3ff5e598f34d2ec1006019f19e6af9798a8fe[m
+Merge: d4d6c64 8ecb173
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 01:09:55 2025 +0900
+
+    Merge pull request #288 from kjoon418/main
+    
+    fix(admin): 소프트 딜리트로 인해 delete가 캐스캐이드 되지 않던 문제 해결
+
+[33mcommit 8ecb17348664a5dabf0a4476286d053e68f6d52f[m
+Merge: cb75aed b14fce5
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 01:07:47 2025 +0900
+
+    Merge remote-tracking branch 'origin/main'
+
+[33mcommit cb75aedaf0b3a5031347c1fb05c3ec7d3179ef08[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 01:07:13 2025 +0900
+
+    fix(admin): 소프트 딜리트로 인해 delete가 캐스캐이드 되지 않던 문제 해결
+
+[33mcommit d4d6c6470899d4f4995d75bf6a27fe4408dbef95[m
+Merge: b14fce5 0838f50
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Dec 13 00:58:49 2025 +0900
+
+    hotfix: User domain 제약조건 추가
+    
+    hotfix: 제약조건 추가
+
+[33mcommit 0838f50c83647e2bdf5ca1f25022da69890fad44[m[33m ([m[1;31morigin/hotfix/#275[m[33m, [m[1;32mhotfix/#275[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 00:52:58 2025 +0900
+
+    chore: Application 안에 @EnableJpaAuditing 추가
+
+[33mcommit b14fce569ebe431483095d20be7418d8ba3859c1[m
+Merge: 5290bc8 cd2b493
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 00:47:18 2025 +0900
+
+    Merge pull request #285 from kjoon418/main
+    
+    feat(admin): 아이디어 복구 API에서 유니크 제약조건으로 인한 문제가 발생하지 않도록 `flush` 추가
+
+[33mcommit cd2b49318b65d9ad2441119e6f11a316f9647c71[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 00:45:55 2025 +0900
+
+    feat(admin): 아이디어 복구 API에서 유니크 제약조건으로 인한 문제가 발생하지 않도록 `flush` 추가
+
+[33mcommit 5290bc8450c37db9366cbac29ae28697ae32960b[m
+Merge: f2b85db 755a0a7
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sat Dec 13 00:38:44 2025 +0900
+
+    Merge pull request #284 from GDG-on-Campus-SKHU/refactor/#251
+    
+    feat(adminActivity) : 썸네일 필드 제거 및 게시물 상세 조회
+
+[33mcommit f2b85db8bf580be7e95927c692bd4a7e29e48d80[m
+Merge: 8dd823f 876e978
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 00:32:54 2025 +0900
+
+    Merge pull request #283 from kjoon418/main
+    
+    feat(admin): 관리자 아이디어 상세 조회 API에서 팀원 구성 정보도 같이 응답하도록 개선
+
+[33mcommit 755a0a78a0cac06319c72a7d32e21a6fbc9a5323[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:32:50 2025 +0900
+
+    refactor(adminActivity) : thumbnailUrl 필드 제거
+
+[33mcommit 876e9782a95f4f6dfeb7dbf1d89aedec3128a22e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 00:31:16 2025 +0900
+
+    feat(admin): 관리자 아이디어 상세 조회 API에서 팀원 구성 정보도 같이 응답하도록 개선
+
+[33mcommit b7459917b3592ce94386d694f559f5e0816fd1c8[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 00:29:41 2025 +0900
+
+    refactor: swagger password 예시 수정
+
+[33mcommit 3c5e441d9c83ef1be053af52483ba69b93c74cd7[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 00:26:21 2025 +0900
+
+    hotfix: AuthServiceImpl 회원가입시 SKHU_ADMIN 값 들어오면 예외처리
+
+[33mcommit e52471d603a70afecf7d4952f5a4eb28e5d98a8e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:25:58 2025 +0900
+
+    refactor(adminActivity) : 필요하지 않은 한줄 제거
+
+[33mcommit 1f63daf8b3406a913e4f0c7596503285a4341e77[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:19:53 2025 +0900
+
+    feat(adminActivity) : 액티비티 게시물 조회 스웨거 문서에 추가
+
+[33mcommit 0245e650b42dad9c49b28e6a83c4d6fbf15123f4[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Dec 13 00:14:00 2025 +0900
+
+    hotfix: Auth, EmailController 에 @Valid 추가
+
+[33mcommit a76fa4f9a8c1d2f355762d5be2af6b14c61f8f12[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:12:57 2025 +0900
+
+    feat(adminActivity) : 액티비티 게시물 조회 기능구현
+
+[33mcommit 8dd823f200203324fcf3ab2adb2f01abcb47da6c[m
+Merge: 012e7c8 bb0cbcb
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 13 00:10:33 2025 +0900
+
+    Merge pull request #282 from kjoon418/main
+    
+    feat(admin): 팀원 삭제 API에서 팀장을 삭제했을 때 더 정확한 에러 메시지를 응답하도록 개선
+
+[33mcommit 1bfb69396371374f9d1f68e402e0028ac8c01813[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:10:06 2025 +0900
+
+    refactor(adminActivity) : dto 클래스에서 thumbnailUrl 제거
+
+[33mcommit 011d1e2d70bc5ce691a1847de78713eff775a22b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:08:57 2025 +0900
+
+    refactor(adminActivity) : Mapper 클래스에서 thumbnailUrl 필드 제거
+
+[33mcommit c21c9f6371bd4d5e43a884dc91c43c37b2ff8ec4[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 13 00:06:27 2025 +0900
+
+    refactor(adminActivity) : 도메인에서 thumbnailUrl 필드 제거
+
+[33mcommit bb0cbcb5654aad39a31bd0d04d204f53639234c4[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 13 00:05:32 2025 +0900
+
+    fix(admin): 관리자 아이디어 상세 조회 API가 소프트 딜리트된 아이디어를 조회하지 못하던 문제 수정
+
+[33mcommit dc8d55a08228768f54d5f9f1ee25135f45a3a629[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 23:58:03 2025 +0900
+
+    feat(admin): 팀원 삭제 API에서 팀장을 삭제했을 때 더 정확한 에러 메시지를 응답하도록 개선
+
+[33mcommit 012e7c8f4c72a510dca80338e9c05b4b048e61e7[m
+Merge: 6f7d32e 328a973
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 23:26:46 2025 +0900
+
+    Merge pull request #281 from TwooTwoo/deploy-process-optimize
+    
+    fix(ci): 배포 시 컨테이너 이름 충돌로 인한 compose 실패 문제 해결
+
+[33mcommit 328a9736385b25b47c474fd713b8b2d798f19747[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 23:25:18 2025 +0900
+
+    fix(ci): 배포 시 컨테이너 이름 충돌로 인한 compose 실패 문제 해결
+
+[33mcommit 6f7d32eb821e759b21a1c1097a298e190d2365f8[m
+Merge: edcf749 dd76756
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 23:17:56 2025 +0900
+
+    Merge pull request #280 from TwooTwoo/deploy-process-optimize
+    
+    fix(ci): 기존 컨테이너, 네트워크 충돌로 인한 배포 실패 문제 수정
+
+[33mcommit dd767565af231220e4327f800f788da54058ad5e[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 23:16:24 2025 +0900
+
+    fix(ci): 기존 컨테이너, 네트워크 충돌로 인한 배포 실패 문제 수정
+
+[33mcommit edcf749c4c5fe10b4c0c45090666c25de278e4cb[m
+Merge: f55efec c19e7e2
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 22:20:39 2025 +0900
+
+    Merge pull request #279 from TwooTwoo/deploy-process-optimize
+    
+    fix(deploy): docker-compose external network 설정 오류 수정
+
+[33mcommit c19e7e24c42dba4ebf77fcafc01eec9ce2498846[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 22:20:02 2025 +0900
+
+    fix(deploy): docker-compose external network 설정 오류 수정
+
+[33mcommit f55efec5c4317721709a41ebf46ead58015a14b9[m
+Merge: 76b0514 7d03e0d
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 21:55:55 2025 +0900
+
+    Merge pull request #278 from TwooTwoo/deploy-process-optimize
+    
+    ci: 배포 로직 정리 및 docker compose 도입
+
+[33mcommit 76b0514d3a232be39b9e2716c85761e1dabb61f6[m
+Merge: 3b866d8 60eaf87
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Fri Dec 12 21:44:59 2025 +0900
+
+    feat(인증/인가): 회원가입, 이메일 제약조건 추가
+    
+    feat(인증/인가): 회원가입 제약조건 추가
+
+[33mcommit 60eaf87d7c08ddca0e8b74758ac86ad8d09fc005[m[33m ([m[1;31morigin/refactor/#270[m[33m, [m[1;32mrefactor/#270[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 21:40:50 2025 +0900
+
+    refactor: EmailController 이메일 인증 API 구조 및 DTO 사용 방식 개선
+
+[33mcommit 7d03e0d355411ae715de538de95cd6c072bb0b7c[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 21:38:30 2025 +0900
+
+    ci: docker compose 기반 배포 플로우로 전환
+
+[33mcommit 3b866d8c2f56bf72ef4f64739747c35b836b88c5[m
+Merge: 4d643f8 6c35692
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Dec 12 21:27:29 2025 +0900
+
+    Merge pull request #276 from ggok0265/main
+    
+    refactor(activity): 기수 필드를 `String`에서 `Generation` enum으로 변경
+
+[33mcommit 6c3569252ebfebc39725abcf55586cdc0af1b9db[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Dec 12 21:24:32 2025 +0900
+
+    refactor(activity): 기수 필드를 `String`에서 `Generation` enum으로 변경
+
+[33mcommit d659079e4d8ba733b7bcf87903555f9c1d133c2e[m
+Merge: d893397 4d643f8
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 21:15:32 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into refactor/#270
+
+[33mcommit d8933976d847c36e170925fc19fbf0ab3736b8fa[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 21:12:06 2025 +0900
+
+    refactor: ResetPasswordService refactoring
+
+[33mcommit 099a440f112edacb57f6ab2a6a93b8fef9c0174f[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 21:10:50 2025 +0900
+
+    refactor: EmailVerificationService refactoring
+
+[33mcommit 4d643f8a068baaadc45c52aa6a362f2e6b95d1ec[m
+Merge: af12484 20bfba0
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Dec 12 21:07:03 2025 +0900
+
+    Merge pull request #274 from ggok0265/main
+    
+    fix(activity): 누락된 `@Enumrated` 어노테이션 추가
+
+[33mcommit 1bef5f77147e7a7d1b910f36d282a1a3a106b86f[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 21:06:12 2025 +0900
+
+    refactor: EmailService refactoring
+
+[33mcommit 20bfba0f9516c95724bd341c66fd37b7d6af7b89[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Dec 12 21:00:11 2025 +0900
+
+    fix(activity): 누락된 `@Enumrated` 어노테이션 추가
+
+[33mcommit 3f0c22113614585d992c59630f1c8796740ea5ef[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 21:01:35 2025 +0900
+
+    feat: ResetPasswordService에서 UserRole에 맞게 예외처리
+
+[33mcommit 66accb0b12f00144022110787ed9d63ecd418719[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 20:43:43 2025 +0900
+
+    chore: AuthController swagger 문서 설명 수정
+
+[33mcommit 33787e42d471df9c2ac96edcdc07508f0e559f10[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 20:41:39 2025 +0900
+
+    feat: AuthServiceImpl에 휴대전화 중복일시 에러 처리 발생 코드 추가
+
+[33mcommit 63a7d186fc7402a31dfd982a0dde8cacc99fcc40[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 20:38:22 2025 +0900
+
+    chore: validateSignUp 중복 코드 제거
+
+[33mcommit 4e0564c04c2586bed23d8ab02159f3b97c6ea7b9[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 20:27:44 2025 +0900
+
+    인가 실패시 403 코드 반환
+
+[33mcommit 8c9d7a6ce16fec6ea6cb495f96d9d02e28320efc[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 20:22:05 2025 +0900
+
+    feat: 인증실패(토큰 없음, 만료, BANNED계정) 예외처리 추가
+
+[33mcommit af12484786ed73b1eea6bf636bc77e8e4d0beb3a[m
+Merge: 403ac87 8575439
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Dec 12 20:19:01 2025 +0900
+
+    Merge pull request #272 from ggok0265/main
+    
+    feat(project gallery): 프젝갤에 썸네일url 필드 추가, 불필요한 파일과 필드 삭제
+
+[33mcommit 857543933ad854adfdd58300a1ce304458e28765[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Dec 12 20:15:09 2025 +0900
+
+    fix(test): 권한 체크시 사용되지 않는 `Role` 타입 제거
+
+[33mcommit d11402ed29c357df54b361a763ab31394379c4ea[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Dec 12 20:11:03 2025 +0900
+
+    feat(project gallery): 프젝갤에 썸네일url 필드 추가, 불필요한 파일과 필드 삭제
+
+[33mcommit ec6482456eaef80289444e6a95a98400a83280b7[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 20:08:35 2025 +0900
+
+    refactor: env 파일이 과도하게 생성되는 문제를 단일 파일 백업 구조로 개선
+
+[33mcommit 90eb58b978c3003af975db6f6892bbf53038e4ca[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 20:07:32 2025 +0900
+
+    feat: 회원가입 시 전화번호 중복시 예외처리
+
+[33mcommit 216ab991cddae04be301baa2bb0cd182791c3f06[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Dec 12 19:56:48 2025 +0900
+
+    refactor: number, email unique 제약조건 추가
+
+[33mcommit 403ac8700d7d311c475c2e8802b02c5e2ad0583b[m
+Merge: ff44241 26b1088
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Dec 12 19:43:13 2025 +0900
+
+    Merge pull request #271 from ggok0265/main
+    
+    fix(activity): `JPA Repository`에 잘못 적혀진 메서드 네이밍 수정
+
+[33mcommit 26b10886258d3526603e7d4ed864247b4997f13b[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Dec 12 19:41:10 2025 +0900
+
+    fix(activity): `JPA Repository`에 잘못 적혀진 메서드 네이밍 수정
+
+[33mcommit ff4424180596505ecd856e7fe6a1ae0ab966de55[m
+Merge: f0fd37b a34d45b
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Dec 12 19:31:25 2025 +0900
+
+    Merge pull request #265 from ggok0265/main
+    
+    refactor(activity): 기수 타입을 `Generation` enum으로 변경
+
+[33mcommit a34d45bad01db1b3898a6ac53b0c5a24a2a308b5[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Dec 12 19:11:51 2025 +0900
+
+    refactor(activity): 기수 타입을 `Generation` enum으로 변경
+
+[33mcommit f0fd37b744eef58a03c3fd1e77347a96728cd206[m
+Merge: 52455d8 a67a28f
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Dec 12 19:11:29 2025 +0900
+
+    Merge pull request #208 from ggok0265/main
+    
+    feat(activity): 액티비티 목록 조회 API 구현
+
+[33mcommit 52455d8332cdb21a21cdc387fe269cfe89a8d39c[m
+Merge: 1c8f5a2 b5c832f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 18:46:20 2025 +0900
+
+    Merge pull request #263 from kjoon418/main
+    
+    fix(admin): 프로젝트를 삭제할 때 발생하는 외래키 제약조건 문제 수정
+
+[33mcommit b5c832f69c6472d999d9de84d0213711d60e5418[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 18:44:59 2025 +0900
+
+    fix(admin): 프로젝트를 삭제할 때 발생하는 외래키 제약조건 문제 수정
+
+[33mcommit 1c8f5a27741c36e7ecd1b821f5d3a057ba40203a[m
+Merge: ea0ca94 4aad0de
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 18:31:47 2025 +0900
+
+    Merge pull request #262 from kjoon418/main
+    
+    fix(domain): `Idea`와 `ProjectTopic`이 1:1 관계였던 문제 수정
+
+[33mcommit 4aad0de2d94b79dcb70d6ae0548da5a63b759403[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 18:30:55 2025 +0900
+
+    fix(domain): `Idea`와 `ProjectTopic`이 1:1 관계였던 문제 수정
+
+[33mcommit ea0ca945a9c1641fa4e64fd72af88f9afae93fa4[m
+Merge: cd05584 ba9a16d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 18:26:35 2025 +0900
+
+    Merge pull request #261 from kjoon418/main
+    
+    feat(domain): 프록시 객체와의 equals도 항상 안전하게 처리되도록 메서드 개선
+
+[33mcommit ba9a16de68e45b49c0e2f6cb2ccfaceac32cb02d[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 18:25:24 2025 +0900
+
+    feat(domain): 프록시 객체와의 equals도 항상 안전하게 처리되도록 메서드 개선
+
+[33mcommit cd055848b0f3e742bfabd7ac480439641f71f8df[m
+Merge: 7cefd78 5499b6b
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 16:51:42 2025 +0900
+
+    Merge pull request #260 from kjoon418/main
+    
+    feat(team building): 프로젝트 조회 API가 `topic`에 관한 정보도 응답하도록 개선
+
+[33mcommit 5499b6bdc150f3b45d779af34668c78ab89105bf[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 16:50:28 2025 +0900
+
+    feat(team building): 프로젝트 조회 API가 `topic`에 관한 정보도 응답하도록 개선
+
+[33mcommit 7cefd7821f1e553606554936b2fb753b1a4f66a5[m
+Merge: 334d1eb ad8b27d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 16:35:52 2025 +0900
+
+    Merge pull request #259 from kjoon418/main
+    
+    feat(team building): 유니크 제약조건과 관련해 문제가 생기지 않도록 update 로직 개선
+
+[33mcommit ad8b27da9e12717792771c10aef1fef4a8ee40bb[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 16:34:34 2025 +0900
+
+    feat(team building): 유니크 제약조건과 관련해 문제가 생기지 않도록 update 로직 개선
+
+[33mcommit 546b5440ed44e06fc6f356fc49ddc605506e843a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 16:34:21 2025 +0900
+
+    feat(team building): `ProjectAvailablePart`에 적절한 유니크 제약조건 지정
+
+[33mcommit 3a5c75fe392f803ef7315b59f95853d14ea3bf4a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 16:09:58 2025 +0900
+
+    fix(team building): 수정 가능한 프로젝트 조회 API에서 `topics`도 제공
+
+[33mcommit 334d1eb1282de329a70b16bcbe9681153b3e1b53[m
+Merge: d954c5c e74f757
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 15:54:00 2025 +0900
+
+    Merge pull request #258 from kjoon418/hotfix-query
+    
+    fix(team building): 종료되지 않은 프로젝트 조회 쿼리 수정
+
+[33mcommit e74f7577561bb96633d09a7215e98404b52529c7[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 15:52:47 2025 +0900
+
+    fix(team building): 종료되지 않은 프로젝트 조회 쿼리 수정
+    
+    기존에는 null 처리가 없었기에, 일정이 설정되지 않은 프로젝트가 조회 대상에서 제외되었음.
+
+[33mcommit d954c5cc51da71ffb04c3d4027519224297452a4[m
+Merge: 1c49457 dc8d504
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 15:41:43 2025 +0900
+
+    Merge pull request #257 from kjoon418/hotfix-npe
+    
+    fix(team building): `TeamBuildingProject`에서 NPE가 발생할 수 있는 코드 수정
+
+[33mcommit dc8d5041b07e41fa2bd10380ebd91d002c295be6[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 15:39:45 2025 +0900
+
+    fix(team building): `TeamBuildingProject`에서 NPE가 발생할 수 있는 코드 수정
+
+[33mcommit 1c494577de0dcd5219aec285e0876b83727981b4[m
+Merge: e507e02 9ba015f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 15:28:32 2025 +0900
+
+    Merge pull request #256 from kjoon418/schedule-type-unique
+    
+    feat(team building): `ProjectSchedule.type`에 적절한 유니크 제약조건 추가
+
+[33mcommit 9ba015f4f89bf897d54a64dc4eb670ab37f55c2d[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 15:27:36 2025 +0900
+
+    feat(team building): `ProjectSchedule.type`에 적절한 유니크 제약조건 추가
+
+[33mcommit e507e021f563cb045360e6c30516d9ddd1c3904a[m
+Merge: 97fc525 dff268c
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 03:54:57 2025 +0900
+
+    Merge pull request #255 from TwooTwoo/mypage-fix-and-enhance
+    
+    fix(image): cors 해결을 위해 /icons 경로 허용
+
+[33mcommit dff268ca102f4a0aaf4f982f681a7d3fed99f712[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 03:49:40 2025 +0900
+
+    fix(image): cors 해결을 위해 /icons 경로 허용
+
+[33mcommit 97fc5255da56e7f202412bcef118d152462b4d28[m
+Merge: 4bf592f 5eeadca
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 03:48:34 2025 +0900
+
+    Merge pull request #254 from TwooTwoo/mypage-fix-and-enhance
+    
+    fix(image): 잘못된 정적 리소스 경로 수정
+
+[33mcommit 5eeadca0032b5b2c732d3803eefa79f3be9903e6[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 03:47:41 2025 +0900
+
+    fix(image): 잘못된 정적 리소스 경로 수정
+
+[33mcommit 4bf592fbb316d107821ce86e23ac02caa07c7685[m
+Merge: 4a4f7d0 0805e40
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 03:38:27 2025 +0900
+
+    Merge pull request #253 from TwooTwoo/mypage-fix-and-enhance
+    
+    fix(securityconfig): 개발중 수정한 securityconfig 파일 원상복구
+
+[33mcommit 0805e401b35376c81792d899a9bcf997e893bd92[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 03:37:24 2025 +0900
+
+    fix(securityconfig): 개발중 수정한 securityconfig 파일 원상복구
+
+[33mcommit 4a4f7d06c69b45d4030e3fc6fc95c341cda392c3[m
+Merge: 3bee12f ce67021
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 03:27:37 2025 +0900
+
+    Merge pull request #252 from TwooTwoo/mypage-fix-and-enhance
+    
+    fix(image): CDN 미작동 링크 확인 및 정적 리소스 추가
+
+[33mcommit ce67021ffc978ca39bee2f741908f3535eb9256f[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 03:11:31 2025 +0900
+
+    fix(image) : 누락된 정적 리소스 경로 추가
+
+[33mcommit 79fb6386250a315aed832f65cca9756efc5ef62e[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 03:06:07 2025 +0900
+
+    fix(image): CDN 미작동 링크 확인 및 정적 리소스 추가
+
+[33mcommit 3bee12f5ec557aec4e9f1542c49d803fba4eaadd[m
+Merge: 31de51d a88ca58
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Fri Dec 12 02:53:56 2025 +0900
+
+    Merge pull request #250 from GDG-on-Campus-SKHU/feature/#39
+    
+    feat(adminDashboard) : 관리자 대시보드 조회API 구현
+
+[33mcommit a88ca586737d1bfec6893b6641339c25eccc92ce[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:50:31 2025 +0900
+
+    feat(adminDashboard) : 누락된 @Transactional(readOnly = true) 추가
+
+[33mcommit ecdd1eb183417bda44c6bcdfeda0eb58460e388b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:50:06 2025 +0900
+
+    feat(adminDashboard) : 누락된 한줄 개행 추가
+
+[33mcommit 4fe27e966478ded3ec902f6e0d24977d5e403b11[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:46:16 2025 +0900
+
+    feat(adminDashboard) : 대시보드 정보 반환용 mapper 클래스 추가
+
+[33mcommit b01210c3b86ccdf90fe2ca6065731205d686fe5e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:45:58 2025 +0900
+
+    feat(adminDashboard) : projectsummary & 대시보드 정보 반환 dto 추가
+
+[33mcommit 306055404ea2c5586523472dc113f9fefcaf31fa[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:44:17 2025 +0900
+
+    feat(adminDashboard) : 유저 레파지토리에 status로 count조회 메서드 추가
+
+[33mcommit 9623fdffc9a9ec67ab65f65783965f552486fb73[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:42:58 2025 +0900
+
+    feat(adminDashboard) : 서비스 레이어에 관리자 대시보드 조회 메서드 추가
+
+[33mcommit eed8a4f6404501b90c135f9ed3e1a2d2093ab02b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:42:31 2025 +0900
+
+    feat(adminDashboard) : 관리자 대시보드 컨트롤러 추가 및 API 추가
+
+[33mcommit 1eb6dcb4978cba7fffb64ef5dc096f351cacd348[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Dec 12 02:42:11 2025 +0900
+
+    feat(adminDashboard) : 관리자 대시보드 스웨거 문서 추가
+
+[33mcommit 31de51d6420544739df78737849ee76e96909180[m
+Merge: cd5327c 6840733
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 02:10:54 2025 +0900
+
+    Merge pull request #248 from TwooTwoo/mypage-fix-and-enhance
+    
+    feat(mypage): 모든 기술스택 목록 조회, 모든 유저링크 목록 조회 기능 구현
+
+[33mcommit 6840733e365087d4988ff80315ed70ad05debcac[m
+Merge: 44441db 8c6d35e
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 02:05:37 2025 +0900
+
+    Merge branch 'mypage-fix-and-enhance' of github.com:TwooTwoo/25-26-GDGoC-Team-Building-System into mypage-fix-and-enhance
+
+[33mcommit 44441dbd67e3274288676cfa86404424b152eadd[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 02:03:39 2025 +0900
+
+    feat(mypage): 모든 유저링크 목록 조회 기능 구현
+
+[33mcommit 0982f30ab655ace90669898b1423954920d78c96[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 01:27:13 2025 +0900
+
+    feat(mypage) : 모든 기술스택 목록 조회 기능 구현
+
+[33mcommit cd5327c7c7b4b833c02095336a15d6b61a3c33da[m
+Merge: d9672f6 8c6d35e
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 01:12:33 2025 +0900
+
+    Merge pull request #247 from TwooTwoo/mypage-fix-and-enhance
+    
+    fix(mypage) : 마이페이지 오류 수정 및 로직 개선
+
+[33mcommit 8c6d35e769dc1473816337936c85b8a32836d12a[m
+Merge: fc7b352 d9672f6
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Fri Dec 12 01:11:14 2025 +0900
+
+    Merge branch 'main' into mypage-fix-and-enhance
+
+[33mcommit b2568e9cda5d3721e751640ab22c6b7592ad81b2[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 01:10:07 2025 +0900
+
+    chore(application.yml): application.yml 파일을 메인과 동일하게 수정
+
+[33mcommit fc7b3525344043283d6d0024a5e8f3ee28314cca[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 01:08:13 2025 +0900
+
+    chore: POSIX new line 수정
+
+[33mcommit b59836bb095bd867a05956cef466ec6d79b8acfe[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Fri Dec 12 01:05:39 2025 +0900
+
+    fix(mypage): 사용자 본인의 프로필 수정시 RequestBody 에서 imageURL을 받지 않도록 수정
+
+[33mcommit a67a28f07430e3ede8890e7852638d7d8ae57498[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Dec 9 01:18:51 2025 +0900
+
+    feat(activity): 액티비티 목록 조회 API 구현
+
+[33mcommit 3a81636ab4c2be0d4d0ed0b6dcb1d1f6da5a01dc[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Dec 9 01:16:11 2025 +0900
+
+    refactor(activity): 기획 변경에 따라 기존 `community` 에서 `activity`로 패키지명 변경
+
+[33mcommit f6e38ea52d47de276599a0874ba8b75f135d43f7[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Dec 9 01:15:32 2025 +0900
+
+    chore(activity): 기획 변경에 따른 불필요한 파일 삭제
+
+[33mcommit d9672f6685122c6b613ee57c291c30e570d501e3[m
+Merge: a48d3cd d404a84
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Dec 12 00:07:48 2025 +0900
+
+    Merge pull request #246 from kjoon418/refactor
+    
+    chore(team building): API Tag를 명확하게 수정
+
+[33mcommit d404a840c726007b89631657505f3855788b084d[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 12 00:06:43 2025 +0900
+
+    chore(team building): API Tag를 명확하게 수정
+
+[33mcommit a48d3cd5b48cb540280b840801964159fe190ba7[m
+Merge: 12b7474 5a6f367
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 11 23:47:03 2025 +0900
+
+    Merge pull request #245 from kjoon418/refactor
+    
+    refactor(team building): 팀빌딩 기능 리팩터링
+
+[33mcommit 5a6f367a3fb7f99e99988fb7de6931de7480166a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 23:39:52 2025 +0900
+
+    refactor(team building): `ProjectUtil`의 책임 분리
+
+[33mcommit 12b74744ed1ce83302dc78e74951b434e4a9d29a[m
+Merge: 7f9bbcd 8b814b4
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Thu Dec 11 23:32:02 2025 +0900
+
+    Merge pull request #244 from TwooTwoo/hotfix-yml
+    
+    hotfix(application) : application.yl 에 누락된 환경변수 추가 및 env.example 수정
+
+[33mcommit eb452ad53557d6550769f90510c09ab2210a7aa9[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 23:29:34 2025 +0900
+
+    refactor(team building): `admin.dto` 패키지의 팀빌딩 관련 클래스들을 `teambuilding.dto` 하위로 재배치
+
+[33mcommit 8b814b43fe59bdc027e673e0a5bc0e387e3b40fa[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Thu Dec 11 23:30:42 2025 +0900
+
+    chore: POSIX NEW LINE 수정
+
+[33mcommit 0cd450fa635687a053b228af4a1c78911437f05b[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Thu Dec 11 23:28:32 2025 +0900
+
+    hotfix(application) : application.yl 에 누락된 환경변수 추가 및 env.example ìì 수정
+
+[33mcommit 70c24560ecd6408c2b105a75031b48ddf09c2413[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 23:27:42 2025 +0900
+
+    refactor(team building): `teambuilding.dto` 패키지 내 클래스들 경로 재배치
+
+[33mcommit 17bf756a3234c9e8ab6403bc03431139e5194187[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 23:21:47 2025 +0900
+
+    refactor(team building): `teambuilding.model` 패키지의 Mapper 클래스들을 `mapper` 패키지 하위로 이동
+
+[33mcommit d39411162776299c87078c097d9ee833aac20e8a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 23:20:25 2025 +0900
+
+    refactor(team building): `idea` 패키지를 `teambuilding` 패키지에 병합
+
+[33mcommit 6ce0d5c161a25f76e68af5ce1140c772b07085b5[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 23:18:50 2025 +0900
+
+    refactor(team building): API 재분배
+
+[33mcommit 7f9bbcd44b7765caf0e77bfd9f8bde2599315381[m
+Merge: a7674ec 5a1a90b
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 11 22:55:20 2025 +0900
+
+    Merge pull request #243 from kjoon418/validate-participate
+    
+    feat(team building): 팀빌딩 관련 기능에 프로젝트에 참여했는지에 대한 검증 로직 추가
+
+[33mcommit 5a1a90b69654602155acc553b06225e543484ebe[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 22:50:12 2025 +0900
+
+    feat(team building): 팀빌딩 관련 기능에 프로젝트에 참여했는지에 대한 검증 로직 추가
+
+[33mcommit d56a8c24d04e1f3e1e7e018c2c20e14706a13197[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Thu Dec 11 22:47:53 2025 +0900
+
+    fix(mypage): 마이페이지에서 사용자 본인의 프로필 조회 및 수정 시 기수 정보를 정상적으로 반환하도록 수정
+
+[33mcommit a7674ecd9fa6a70d279f45dd2dcb622940b3f9a0[m
+Merge: 007ee12 e147ecb
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Dec 11 22:31:18 2025 +0900
+
+    Merge pull request #242 from GDG-on-Campus-SKHU/refactor/#241
+    
+    refactor(UserMapperTest) : 리펙토링된 로직 수정사항에 맞게 테스트 코드 리펙토링 진행
+
+[33mcommit e147ecb83619b177ad41dce36f50d468cb0c72dd[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 22:29:18 2025 +0900
+
+    refactor(UserMapperTest) : 마지막 줄 개행 추가
+
+[33mcommit ed5fab147fe6d4dd710e5441453aa2bf7c37799b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 22:28:32 2025 +0900
+
+    refactor(UserMapperTest) : 리펙토링된 로직 수정사항에 맞게 테스트 코드 리펙토링 진행
+
+[33mcommit 23fabe6a26602940d40278830a7f72ed7c6e94f5[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 21:43:28 2025 +0900
+
+    refactor(adminDashboard) : getDashboard API 추가
+
+[33mcommit 007ee12a69c6b54bd22e6292a5dd16a307d86bb8[m
+Merge: 66e6285 4e76691
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 11 21:41:04 2025 +0900
+
+    Merge pull request #240 from kjoon418/topic
+    
+    feat(team building): 프로젝트 주제 기능 개선
+
+[33mcommit 4e766913e90b2024661c2da6fde86ae6e0fadc0f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 21:36:48 2025 +0900
+
+    feat(team building): 아이디어 CRUD API에 `topic` 변경 반영
+
+[33mcommit 66e628586d15415debf77329d9b67834ceef1ad2[m
+Merge: b3c9afc b4fada9
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Dec 11 21:15:29 2025 +0900
+
+    Merge pull request #202 from GDG-on-Campus-SKHU/feature/#177
+    
+    feat(adminUserProfile) : 관리자의 특정 유저 마이페이지 프로필 조회 & 수정
+
+[33mcommit b4fada9b22d4bbbfcab59c573f1b0f6541b1b8b1[m
+Merge: 0a8ee20 b3c9afc
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 21:10:24 2025 +0900
+
+    refactor(adminUserProfile) : 프로필 관리 기능 머지 완료
+
+[33mcommit 0a8ee2027f37ad7b3c49fd0253e5415f35d8e3b9[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 21:01:45 2025 +0900
+
+    refactor(adminUserProfile) : main과 머지하면서 충돌난 파일 병합
+
+[33mcommit 480eb6370a4206b6203cebc7e7109b95ba1bbb60[m
+Merge: 890c038 51fd78d
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 21:00:39 2025 +0900
+
+    Merge branch 'main' into feature/#177
+
+[33mcommit 890c038645f25c57b0a8cc0448196be82ae93fe8[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 20:50:52 2025 +0900
+
+    refactor(adminUserProfile) : 코드리뷰 반영해 mapper 리펙토링 진행
+
+[33mcommit b3c9afc5164494ac7ee1f06119ad38ac974b44a5[m
+Merge: 51fd78d 792ab01
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Dec 11 20:48:43 2025 +0900
+
+    Merge pull request #183 from GDG-on-Campus-SKHU/feature/#182
+    
+    feat(adminUserProfile) : 프론트에서 필요한 셀렉트 데이터 로드 API
+
+[33mcommit 856238f381e10f8a80595dba0849ee3650540132[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 20:47:50 2025 +0900
+
+    refactor(team building): 가독성 개선 및 DTO에 `null` 방어 위임
+
+[33mcommit 792ab018553c07c407402326fb741fd9315322f5[m
+Merge: 85e1dea 51fd78d
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 11 20:44:02 2025 +0900
+
+    Merge branch 'main' into feature/#182
+
+[33mcommit 761953e354b4bc821e310ea860db382573e329e9[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 20:40:07 2025 +0900
+
+    feat(team building): 프로젝트에 'topic' 추가
+
+[33mcommit 51fd78d125be96b928e705709b769bd01430f008[m
+Merge: d5e1980 9e59425
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 11 13:00:29 2025 +0900
+
+    Merge pull request #237 from kjoon418/read-modifiable-project-enhance
+    
+    feat(admin): 이미 시작한 프로젝트도 수정 가능하도록 조회 조건 수정
+
+[33mcommit 9e59425243c1c703cd6ca91f3f0e5d85f6f40810[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 12:28:17 2025 +0900
+
+    test(team building): `TeamBuildingInfoMapper` 변경에 대한 테스트 누락 추가
+
+[33mcommit 390af654563006e213446e0bcc5289a6092eca78[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 12:14:42 2025 +0900
+
+    feat(admin): 이미 시작한 프로젝트도 수정 가능하도록 조회 조건 수정
+
+[33mcommit d5e1980eaecc66ef58c6a9c9f3c549a7cb8b9f4c[m
+Merge: 82d9584 c59c95f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 11 12:01:25 2025 +0900
+
+    Merge pull request #236 from kjoon418/fix-empty-schedule
+    
+    feat(team building): 공백 일정에서도 제대로 동작하도록 개선
+
+[33mcommit c59c95f373c96589323c28d8a51c2af4aa4d0d70[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 11:55:05 2025 +0900
+
+    feat(team building): 명세서 개선
+
+[33mcommit be764db2d1333372c523dad56f54f22184f3bbae[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 11:54:46 2025 +0900
+
+    fix(team building): 프로젝트 정보 및 일정 조회 API가 공백 일정에도 정상 동작하도록 개선
+
+[33mcommit a67c85e1d7faf92bc539a08b34536fc500034a85[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 11:38:57 2025 +0900
+
+    fix(team building): 공백 일정에서 문제가 발생할 수 있는 코드 수정
+
+[33mcommit 82d95847251960ff63eec303ef3044892550f54e[m
+Merge: abe0852 7de3451
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Dec 11 01:32:55 2025 +0900
+
+    Merge pull request #185 from GDG-on-Campus-SKHU/feature/#184
+    
+    feat(adminActivity) : 카테고리 타이틀 수정 & 게시/미게시 수정 API
+
+[33mcommit abe0852e661b05d515db0af3a15117a4c8b39f1c[m
+Merge: c9ef211 f2addea
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 11 00:30:20 2025 +0900
+
+    Merge pull request #235 from kjoon418/update-project-enhance
+    
+    feat(team building): 프로젝트 수정 API가 일정도 수정하도록 개선
+
+[33mcommit f2addeac18651c6a94896f8ce0b92d3b1c742979[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 11 00:28:38 2025 +0900
+
+    feat(team building): 발표 일정은 endDate 값을 받지 않도록 개선
+
+[33mcommit c9ef21124bf669b640ed48215f97b7f29175bbc5[m
+Merge: cdd362f 89ec8e8
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Dec 11 00:00:56 2025 +0900
+
+    Merge pull request #204 from GDG-on-Campus-SKHU/feature/#203
+    
+    feat(adminUserProfile): 기수-역할 매핑 로직 분리 및 ApprovedUserInfoMapper 클래스명 변경
+
+[33mcommit fe36d3d29a4b9e87d668e9a02cfc9c7924a01b19[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 23:52:47 2025 +0900
+
+    feat(team building): 프로젝트 수정 API가 일정도 수정하도록 개선
+
+[33mcommit cdd362f5c8c413a86dd2b146d053cbe89d877fb2[m
+Merge: dafe4f0 f2342c9
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 23:29:27 2025 +0900
+
+    Merge pull request #233 from kjoon418/create-project-enhance
+    
+    feat(team building): 새 프로젝트 등록에 대한 검증 로직 추가
+
+[33mcommit f2342c92756f873180c5cbeec0474eb86ee25b9f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 23:25:26 2025 +0900
+
+    feat(team building): 새 프로젝트 등록에 대한 검증 로직 추가
+
+[33mcommit dafe4f01f73d373b4d14158aad3048e55b8a42ed[m
+Merge: 91e1b01 3bfbbd1
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 23:23:20 2025 +0900
+
+    Merge pull request #232 from TwooTwoo/deploy#226
+    
+    fix(deploy): AWS S3 IAM 인증 관련 환경변수 주입하도록 수정, env.example 그에 맞게 수정
+
+[33mcommit 3bfbbd188d54ab817fd0c521c6eee6b5a1ee299f[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 23:19:28 2025 +0900
+
+    fix(deploy): AWS S3 IAM 인증 관련 환경변수 주입하도록 수정, env.example 그에 맞게 수정
+
+[33mcommit 91e1b01f062f5b2077cdb68c3c197bca5bd53b7e[m
+Merge: b3510c2 d339448
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 23:17:58 2025 +0900
+
+    Merge pull request #231 from kjoon418/scheduler-enhance
+    
+    fix(team building): 스케줄러가 모집 마감을 기준으로 동작하도록 수정
+
+[33mcommit d3394482715d295fb79f0e9adb1c340024c05e57[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 23:16:20 2025 +0900
+
+    fix(team building): 스케줄러가 모집 마감을 기준으로 동작하도록 수정
+
+[33mcommit b3510c257f4ecb45494aa76bd2c78a4965142fa1[m
+Merge: 1e6c267 6774106
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 23:04:37 2025 +0900
+
+    Merge pull request #230 from TwooTwoo/deploy#226
+    
+    fix(deploy) : 환경변수 수정 및 배포 설정 수정
+
+[33mcommit 6774106f12e49d05b96d1edbf9fa96304d65d142[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 22:55:31 2025 +0900
+
+    fix(deploy): 스프링에 주입하는 SPRING_DATA_REDIS_HOST 환경변수 입력값 수정, 스프링에 주입하는 SPRING_DATA_REDIS_HOST 와 SPRING_DATA_REDIS_PORT 환경변수 시크릿 도입
+
+[33mcommit 8ce791b5186ae0f95e803c5ea653ec4836159338[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 22:51:42 2025 +0900
+
+    fix(deploy): redis 컨테이너의 이름을 tbs-redis 으로 생성하도록 수정
+
+[33mcommit 21727fcec34285d9f3709005b784915dae7c4cf7[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 22:49:48 2025 +0900
+
+    fix(deploy): EOF 가 두번 있던 것을 수정
+
+[33mcommit 1e6c2676d01b2113286537a311b132a749842a8e[m
+Merge: d0c5ba4 165ce81
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 22:43:21 2025 +0900
+
+    Merge pull request #229 from TwooTwoo/deploy#226
+    
+    fix(deploy): 403 에러 해결을 위해 배포 스크립트에 환경변수 추가
+
+[33mcommit 165ce81519e2f17f1d18a1c700d7063ff792ab59[m
+Merge: a525afa d0c5ba4
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 22:39:39 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into deploy#226
+
+[33mcommit a525afa145da88f1ce68830921ea9b2f49311ea6[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 22:36:30 2025 +0900
+
+    deploy: CORS 환경변수 주입 및 설정 추가
+
+[33mcommit d0c5ba4e9b32ca53a54a185375d068bb538a72d8[m
+Merge: 6ac1826 36d2cd1
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Wed Dec 10 22:32:48 2025 +0900
+
+    hotfix(인증/인가): 이메일 인증 리팩토링, 회원가입 제약조건 추가
+    
+    hotfix(인증/인가): 이메일 인증 리팩토링, 회원가입 제약조건 추가
+
+[33mcommit 36d2cd105970bf479ba3d3b3a42d721952dbc20c[m[33m ([m[1;31morigin/hotfix/#219[m[33m, [m[1;32mhotfix/#219[m[33m)[m
+Merge: 48a9617 7eea169
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 22:32:00 2025 +0900
+
+    merge: main파일과 충돌난 부분 해결
+
+[33mcommit 6ac182652a29b839e5a567392841f0ffe7dee77d[m
+Merge: 7eea169 9091135
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 22:26:50 2025 +0900
+
+    Merge pull request #228 from kjoon418/read-project-enhance
+    
+    feat(team building): 진행중인 프로젝트 조회 API가, 일정이 모두 확정된 프로젝트만 조회하도록 개선
+
+[33mcommit 909113548c9114981fe2a172e0a00903acd037cb[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 22:25:13 2025 +0900
+
+    feat(team building): 진행중인 프로젝트 조회 API가, 일정이 모두 확정된 프로젝트만 조회하도록 개선
+
+[33mcommit 7eea1698bb755da777158d998f3c368f91f7a0bf[m
+Merge: 080cb91 b11fc87
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Wed Dec 10 22:21:33 2025 +0900
+
+    hotfix(인증/인가): swagger 403 오류 수정, auth api 쿠키로 변경
+    
+    hotfix(인증/인가): swagger 403 오류 수정, auth api 쿠키로 변경
+
+[33mcommit b11fc8772a34f93de1f22c43ff20bca44882e4ca[m[33m ([m[1;31morigin/hotfix/#214[m[33m, [m[1;32mhotfix/#214[m[33m)[m
+Merge: e688fd3 080cb91
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 22:20:46 2025 +0900
+
+    merge: yml 파일 충돌 해결
+
+[33mcommit 080cb91fc4e206096719df0395899473b2f25bde[m
+Merge: 81ac2cf d0080c2
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 22:18:29 2025 +0900
+
+    Merge pull request #227 from TwooTwoo/deploy#226
+    
+    feat(redis): Redis 연결을 위한 설정 추가 및 배포 스크립트 보완
+
+[33mcommit d0080c2b71b4530ca415f102703d4e6f43db1a6c[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 22:14:31 2025 +0900
+
+    fix(deploy): ì오타 수정
+
+[33mcommit b768872363bdc1a7b1471f7d5f6dbb68905116e7[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 22:11:03 2025 +0900
+
+    feat(redis): Redis 연결을 위한 설정 추가 및 배포 스크립트 보완
+
+[33mcommit e688fd3999dc95635a75163a5bb8992583935b63[m
+Merge: 4bb2063 0c0597c
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 22:03:46 2025 +0900
+
+    merge: main 파일과 merge
+
+[33mcommit 81ac2cfc374800f3fb45d3ccc03beb862ed79c10[m
+Merge: 0c0597c ad63980
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 21:48:15 2025 +0900
+
+    Merge pull request #224 from kjoon418/idea-register-enhance
+    
+    feat(team building): 아이디어 등록시 최대 멤버 수 검증
+
+[33mcommit 4bb20637749fe77e59428a452e8d9589977e75df[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 21:47:26 2025 +0900
+
+    refactor: 리뷰어 피드백 반영 수정
+
+[33mcommit ad639809025e66ec8d89137f21ca8001ea9b40f8[m
+Merge: 0cc48a0 0c0597c
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 21:46:48 2025 +0900
+
+    Merge branch 'main' into idea-register-enhance
+
+[33mcommit 0c0597c43e13b46e4b0e3eb01a0afb8b23645a62[m
+Merge: f32c61b 3f30294
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 21:40:41 2025 +0900
+
+    Merge pull request #223 from kjoon418/idea-update-enhance
+    
+    feat(team building): 아이디어 수정에 검증 로직 추가
+
+[33mcommit 3f302949fca48b67b56209923fede2054d946e6e[m
+Merge: fa4132a f32c61b
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 21:37:43 2025 +0900
+
+    Merge branch 'main' into idea-update-enhance
+
+[33mcommit f32c61b1a16587b9769972977375e2a958c2b7fe[m
+Merge: 561cb8f 24a107c
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 21:28:37 2025 +0900
+
+    Merge pull request #205 from kjoon418/search-generations
+    
+    feat(admin): 기수 목록 조회 API 구현
+
+[33mcommit 24a107cede8e902e8bf4b5420e17fcdf54570321[m
+Merge: af247be 561cb8f
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 21:21:37 2025 +0900
+
+    Merge branch 'main' into search-generations
+
+[33mcommit 561cb8f540af62e9179f7e887f8b206346bea85d[m
+Merge: 30d8e4e b7e426f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 21:16:37 2025 +0900
+
+    Merge pull request #225 from kjoon418/delete-member-admin
+    
+    fix(team building): 메서드 제거가 반영되지 않은 문제 수정
+
+[33mcommit b7e426f2dc817c209910d9cfd9c1aa33efb06454[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 21:14:03 2025 +0900
+
+    fix(team building): 메서드 제거가 반영되지 않은 문제 수정
+
+[33mcommit 30d8e4e8ed477d9fd520cfe35f1d3b4383f4ff07[m
+Merge: a84a57f 5732316
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 21:11:11 2025 +0900
+
+    Merge pull request #222 from kjoon418/delete-member-admin
+    
+    feat(admin): 관리자용 팀원 제거 API 구현
+
+[33mcommit 5732316a7a90121b2e9ac221337191c8f31035bd[m
+Merge: bef63a6 a84a57f
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 21:10:49 2025 +0900
+
+    Merge branch 'main' into delete-member-admin
+
+[33mcommit a84a57fad158386e5574a8fcd017f5198ca471f2[m
+Merge: 76a4bd8 944631f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 20:58:40 2025 +0900
+
+    Merge pull request #211 from kjoon418/delete-member
+    
+    feat(team building): 멤버 삭제 API 구현
+
+[33mcommit 76a4bd836846c9b0066e24ff4133de1aa52ef550[m
+Merge: 2d825eb afc4907
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 20:58:29 2025 +0900
+
+    Merge pull request #216 from kjoon418/read-apply-enhance
+    
+    feat(team building): 지원 현황 조회 API가 일정 종료 여부도 응답하도록 개선
+
+[33mcommit 2d825ebbc6d672031be86ed63b6f704bd4823943[m
+Merge: 024fb52 5858c4e
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 20:58:08 2025 +0900
+
+    Merge pull request #189 from TwooTwoo/feature#143
+    
+    feat(image) : S3버킷을 이용한 이미지 업로드 및 이미지 삭제 기능 구현
+
+[33mcommit 024fb52b7e44ecf20bc444e6719923d34f970a76[m
+Merge: 01bb2e5 c5b82cb
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 10 20:57:52 2025 +0900
+
+    Merge pull request #209 from kjoon418/enrollment-deletable-read
+    
+    feat(team building): 팀 구성 정보 조회 API 개선
+
+[33mcommit 5858c4e75b1b5cb3fc4c43eac3b61b837a6a9739[m
+Merge: 00d7da4 01bb2e5
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Dec 10 20:56:25 2025 +0900
+
+    Merge branch 'main' into feature#143
+
+[33mcommit 48a96174bc88f82299dc2b8d390f7cc8cb46e4c9[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 20:48:10 2025 +0900
+
+    chore: SignUpRequest, 리뷰에 맞춰 제약 조건 수정.
+
+[33mcommit 0cc48a0d360e156c8f058564cc1ff75fa38b241b[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 19:51:24 2025 +0900
+
+    feat(team building): 아이디어 등록시 최대 멤버 수 검증
+
+[33mcommit 00d7da4fba665bf978c1ed4acc08dc70dba14eca[m
+Author: ãTwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 10 16:37:04 2025 +0900
+
+    refactor(s3) : 이미지 삭제시 사용자 요청에 의한 삭제와 트랜잭션 롤백에 의한 삭제 로직을 분리
+
+[33mcommit fa4132a857c2da13be33417e333d90a859fd9b5f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 12:34:36 2025 +0900
+
+    feat(team building): 아이디어 수정에 검증 로직 추가 및 `recruiting` 상태 변경 개선
+
+[33mcommit bef63a67d29c7599cb984828aba078033d7ce76b[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 12:20:50 2025 +0900
+
+    refactor(admin): 메서드명 수정
+
+[33mcommit f5169bb18da9dcfaf70eaf0b6623186d5b6dfd78[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 10 12:17:25 2025 +0900
+
+    feat(admin): 관리자용 팀원 제거 API 구현
+
+[33mcommit 4f1795a5bd38aa9447d636c9ed64c54a7f817f5a[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 03:54:30 2025 +0900
+
+    feat(auth): refreshToken rotate 방식 복원 및 refresh 로직 리팩토링
+
+[33mcommit d516ccd271b32fcd32534469ad67fed8f8f5d0ee[m
+Merge: 4a4f7cd 01bb2e5
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 03:31:59 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into hotfix/#219
+
+[33mcommit 4a4f7cdbde7cfcbe7276df82ea7159b879229d0f[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 03:31:41 2025 +0900
+
+    chore: 회원가입시 제약조건 설정 추가
+
+[33mcommit 5e6949cc39db33b800b3caa8b9b0352c9aa904c2[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 03:20:43 2025 +0900
+
+    refactor: email 로직 리팩토링
+
+[33mcommit 07a09ffaab156a95f7228ba36bf7c96ef523a1ef[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 02:32:35 2025 +0900
+
+    refactor: auth api 리팩토링
+
+[33mcommit b5eb7c7977a2ac9f6b57523a353536d421146829[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 00:52:49 2025 +0900
+
+    chore: SecurityConfig 환경변수 처리
+
+[33mcommit b8a75f35e623d1cbe2d08bea8a2cdcce1d1ad489[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 00:20:45 2025 +0900
+
+    fix: AuthController 주석 수정
+
+[33mcommit 02df73bb3efcc3a3bd41b96227501bd54151e3e8[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 10 00:06:30 2025 +0900
+
+    chore: UserRole Enum타입 수정
+
+[33mcommit 7a8a071ed68c3eedf7616abd5bbabe7db3ad0b1b[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Dec 9 23:58:39 2025 +0900
+
+    hotfix: allowedOrigins에 localhost:3000 및 gdg-tbd.duckdns.org 추가
+
+[33mcommit 01bb2e5f9f012cebac9cd29288795b08a10b177d[m
+Merge: 28edec3 d30082c
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 23:55:37 2025 +0900
+
+    Merge pull request #217 from kjoon418/hotfix-dto
+    
+    fix(team building): 잘못 제거된 클래스 복구
+
+[33mcommit d30082cf45ae4af8daea5c9f1bdf92393abcd5e3[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 23:54:39 2025 +0900
+
+    fix(team building): 잘못 제거된 클래스 복구
+
+[33mcommit 84dbaf30fea55e7e2b3b391a9b9451f65b35cea1[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Dec 9 23:48:44 2025 +0900
+
+    chore: 이메일 인증시 비밀번호 재설정 주소 변경
+
+[33mcommit 7a77875120eae2fee22f905ac863e89ba35d84ff[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Dec 9 23:35:46 2025 +0900
+
+    feat: Refresh Token을 HttpOnly 쿠키로 전달하도록 인증 구조 변경
+
+[33mcommit 28edec3309bde9a75db925b48f0aecaba8606b53[m
+Merge: 76bcb29 22c997d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 23:20:22 2025 +0900
+
+    Merge pull request #199 from kjoon418/exception-handler
+    
+    feat(exception): 전역 예외 핸들러 구현
+
+[33mcommit 76bcb29d70e54db771eca0b41c0f2057b8497497[m
+Merge: bc87a23 583e673
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 23:20:06 2025 +0900
+
+    Merge pull request #196 from kjoon418/read-current-project-enhance
+    
+    refactor(team building): 진행중인 프로젝트 조회 API 리팩터링
+
+[33mcommit bc87a23ccfb62ebe174f8fa105838b5817942ab6[m
+Merge: ac4ec71 8af9f63
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 23:19:53 2025 +0900
+
+    Merge pull request #192 from kjoon418/read-school-list
+    
+    feat(admin): 학교 목록 조회 API 구현
+
+[33mcommit 8af9f63c54ed2f1a84ae3a2814e78a4b9e4c0935[m
+Merge: 30da7ce ac4ec71
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 23:18:44 2025 +0900
+
+    Merge branch 'main' into read-school-list
+
+[33mcommit afc4907299a295140338e3c7a3b33a6958118e06[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 23:14:05 2025 +0900
+
+    feat(team building): 지원 현황 조회 API가 일정 종료 여부도 응답하도록 개선
+
+[33mcommit ac4ec71e638643c84829c07aa3d0f8c4bc442d5e[m
+Merge: 0a0df7b 36c8848
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 23:01:23 2025 +0900
+
+    Merge pull request #215 from kjoon418/main
+    
+    fix: 커밋 충돌 해결
+
+[33mcommit 36c8848e67f16af055efdf719be56e856699df52[m
+Merge: 0c6eaff 0a0df7b
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 23:01:16 2025 +0900
+
+    Merge branch 'main' into main
+
+[33mcommit 0a0df7b5c1928c8aa51147f3d920f6e14af2d3a4[m
+Merge: 697accc e65b953
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 22:50:56 2025 +0900
+
+    Merge pull request #194 from kjoon418/enrollment-enhance
+    
+    feat(team building): 지원 API 검증로직 개선
+
+[33mcommit 697acccb9044c9c37a8c3a33cfa6afe393c82d15[m
+Merge: 5ee63ae 79d8b3f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 22:50:37 2025 +0900
+
+    Merge pull request #193 from kjoon418/read-project-admin
+    
+    feat(admin): 관리자용 아이디어 상세 조회 API 구현
+
+[33mcommit 5ee63ae4e30566f0296ac2868ac7a12b681c6ae7[m
+Merge: 7e139cc 99f7d87
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 22:49:16 2025 +0900
+
+    Merge pull request #200 from kjoon418/search-user
+    
+    feat(admin): 기수와 학교명을 기반으로 한 회원 검색 API 구현
+
+[33mcommit 99f7d8719c820090ff5cbf1fd5a4c208ddf1a32b[m
+Merge: 725d684 7e139cc
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 22:48:04 2025 +0900
+
+    Merge branch 'main' into search-user
+
+[33mcommit b3e3ae9272a62cfc83d2a8dc678ded54839ec6db[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Dec 9 22:17:09 2025 +0900
+
+    hotfix: JWT 필터에서 인증 불필요한 경로 제외하여 403 오류 해결
+
+[33mcommit 7e139cc0dbf26e13d9c76395d677d3f0849a5804[m
+Merge: 148cd83 efb5442
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 9 21:28:59 2025 +0900
+
+    Merge pull request #190 from kjoon418/delete-project
+    
+    feat(admin): 프로젝트 삭제 API 구현
+
+[33mcommit 148cd83760d48b83a85ec75a9a15fc2a8c584776[m
+Merge: f299626 3e8a223
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Tue Dec 9 18:15:36 2025 +0900
+
+    Merge pull request #213 from TwooTwoo/feature#212
+    
+    chore(deploy): 배포 환경 DB를 RDS에서 Docker의 MySQL 컨테이너로 전환
+
+[33mcommit 3e8a223f934a7446e1f9280765d85b7970104503[m
+Author: glucagon12 <woo991212@nate.com>
+Date:   Tue Dec 9 18:04:11 2025 +0900
+
+    chore(deploy): 배포 환경 DB를 RDS에서 Docker의 MySQL 컨테이너로 전환
+
+[33mcommit f2996265b9068a23b282ac6f83eee4e9ea62b4bc[m
+Merge: 3e875ba d531150
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Tue Dec 9 15:39:39 2025 +0900
+
+    Merge pull request #181 from GDG-on-Campus-SKHU/feature/#180
+    
+    feat(adminUserProfile) : 관리자의 유저 기수-역할 삭제 API 추가
+
+[33mcommit 944631fb0dddbefc65a90c88691bba872d66b06f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 15:15:00 2025 +0900
+
+    fix(team building): 지원을 삭제하지 않고 '수락' 상태로 전이하도록 수정
+
+[33mcommit 093651032875dc68598a7d0f213c7ba395739aab[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 15:08:37 2025 +0900
+
+    feat(team building): 멤버 삭제 API 구현
+
+[33mcommit c5b82cba1a24f5cb98653077aa169bfb7d72ee95[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 14:36:50 2025 +0900
+
+    fix(team building): 응답 정보에 `Creator`가 포함되지 않았던 문제 해결
+
+[33mcommit a0c026f93972bbe9dd66c0420a0dfb257a631eaf[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 14:18:39 2025 +0900
+
+    fix(team building): `currentMemberCount`가 수락 예정인 멤버를 포함하지 않던 문제 수정
+
+[33mcommit be3876d3453e16a12b4db3f36ea2b2a6bd858862[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 14:17:24 2025 +0900
+
+    feat(team building): 팀원 구성 조회 API 개선
+    
+    응답 형태 수정.
+    `IdeaEnrollment`를 기반으로 동작하도록 수정.
+
+[33mcommit e9e13eeb32df8d20c13086f8d8f4a99ad4f14f07[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 9 13:37:28 2025 +0900
+
+    feat(team building): 팀 구성 정보 조회 API 개선
+    
+    팀원 삭제 여부도 같이 조회하도록 개선. 매퍼 책임 관계 리팩터링.
+
+[33mcommit 3e875bafffa2571f4632bc58c43c3396270de006[m
+Merge: 6427cbd 8ee28b3
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Tue Dec 9 05:38:28 2025 +0900
+
+    hotfix: swagger 403 에러 수정
+    
+    hotfix: swagger 403 에러 수정
+
+[33mcommit 6427cbd4657625e3ecdee0e8f12abce51be1ba39[m
+Merge: 3b222cb 1a71c2b
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Mon Dec 8 23:47:26 2025 +0900
+
+    Merge pull request #187 from GDG-on-Campus-SKHU/feature/#186
+    
+    feat(Auth): BANNED된 사용자의 로그인 시도 시 예외 처리
+
+[33mcommit d531150e8e8c5393594179ca61bd38b49cd90edc[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 23:35:59 2025 +0900
+
+    refactor(adminUserProfile) : 스웨거 문서에 잘못된 200 -> 204 응답 상태로 description 수정
+
+[33mcommit 7de3451db999e0d830ca209d0877255ad661fd51[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 23:31:04 2025 +0900
+
+    refactor(adminActivity) : 누락된 @Override 추가
+
+[33mcommit f8c17e7073283043d96f524f4fa75ff861828063[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 23:28:36 2025 +0900
+
+    refactor(adminActivity) : 응답바디가 없으므로 204 응답상태 반환 리펙토링
+
+[33mcommit 7f5f9a1516f6307da4297a8e4a88b57204ad5d15[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 23:28:12 2025 +0900
+
+    refactor(adminActivity) : ActivityCategory 클래스 boolean 필드 isPublished를 published로 변경
+
+[33mcommit 3b222cb14f11a1e10a6c69a2694e4dde1df2c375[m
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Mon Dec 8 20:36:02 2025 +0900
+
+    docs(readme): update README
+
+[33mcommit 8ee28b34afd3c7c3c5e9bce4cefa1e6a307ce1cf[m[33m ([m[1;31morigin/hotfix/#188[m[33m, [m[1;32mhotfix/#188[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 8 12:43:44 2025 +0900
+
+    chore: swagger 설명 수정. PM, BACKEND 추가
+
+[33mcommit af247be23bdebbc8cdd336584fd56b86a05663b0[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 8 09:57:38 2025 +0900
+
+    chore(admin): 권한 상관 없이 호출할 수 있도록 개선
+
+[33mcommit a3180ec1767b4c081ca0f2bbd5936a671047f050[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 8 09:50:46 2025 +0900
+
+    feat(admin): 기수 목록 조회 API 구현
+
+[33mcommit 89ec8e88fa6f6f8348030a4ea79a3dcd94d5c8e4[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 02:46:17 2025 +0900
+
+    refactor(mapper) : 서비스레이어에 ApprovedUserInfoMapper -> ApprovedUserDetailMapper으로 변경
+
+[33mcommit 7c6fb4637f570eab539e617107302e916d19b4e5[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 02:45:56 2025 +0900
+
+    refactor(mapper) : ApprovedUserInfoMapper -> ApprovedUserDetailMapper으로 변경
+
+[33mcommit 5ab9d224d953c5ba3df9ba8d5431260fe080fe95[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 02:45:33 2025 +0900
+
+    refactor(mapper) : ApprovedUserGenerationResponseDto 리스트 타입으로 필드 변경
+
+[33mcommit 146a58dea8d81318ee2111bfcda0459cc0b7019f[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 02:45:15 2025 +0900
+
+    refactor(mapper) : GenerationMapper로 리펙토링 및 delete된 유저는 name만 반환
+
+[33mcommit 3c8f25b08a4cafa72e11db370d0e0499071d4d2e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 02:44:34 2025 +0900
+
+    refactor(mapper) : GenerationMapper로 리펙토링
+
+[33mcommit bb064b1fefdfaf62becf3e688748ccf6bababb76[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 02:44:00 2025 +0900
+
+    feat(mapper) : 유저 기수-역할(Main) 매핑 로직을 GenerationMapper로 분리
+
+[33mcommit 58b1895ac2f860879168f0eec7a3eb5e6fd41e58[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:41:15 2025 +0900
+
+    refactor(AdminUserProfile) : 스웨거 문서 설명 수정
+
+[33mcommit 09fc2fb3d2b58f92d31e0b8731f02b582061c14c[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:33:38 2025 +0900
+
+    feat(AdminUserProfile) : UserProfileResponseDto에 기수-역할용 리스트 필드 추가
+
+[33mcommit c2f9850cfbba771a3b7e3ede9527d85e600e20c5[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:33:18 2025 +0900
+
+    feat(AdminUserProfile) : 프로필 수정용 mapper 클래스 추가
+
+[33mcommit 8a65d5671ed35efcf5414920c34ea5a62b85ea0c[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:32:16 2025 +0900
+
+    feat(AdminUserProfile) : 프로필 조회용 mapper 클래스에 mapGenerations 메서드 추가
+
+[33mcommit 6c18d29e5a0a3463c55ac7cdaaa8e5436a045a15[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:30:21 2025 +0900
+
+    feat(AdminUserProfile) : 프로필 스택, 링크, 자기소개 update 용 dto 추가
+
+[33mcommit 14943699e1f09953e7b648804c025c6dfabaf6c3[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:30:01 2025 +0900
+
+    feat(AdminUserProfile) : 서비스레이어에 관리자의 회원 마이페이지 프로필 조회 & 수정 메서드 추가
+
+[33mcommit a236977300dabf0099b604b8d19ea28ce05c3180[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:28:03 2025 +0900
+
+    feat(AdminUserProfile) : 컨트롤러에 관리자의 회원 마이페이지 프로필 조회 & 수정 API 추가
+
+[33mcommit a8a3447da912661a9294f2bf2d2de4dba0022bae[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 8 01:27:36 2025 +0900
+
+    feat(AdminUserProfile) : 관리자의 회원 마이페이지 프로필 조회 & 수정 스웨거 문서에 추가
+
+[33mcommit 729652c83991a4ccd7b8e5cca4d688fb625ff460[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 8 00:12:40 2025 +0900
+
+    fix: swaggerconfig 파일 재제출
+
+[33mcommit 1ed289b976290be669a60e09dbaf7ae72728ad83[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 23:46:50 2025 +0900
+
+    fix: fromLabel 사용하여 메서드 구현
+
+[33mcommit c0f122bf39b843490993d804b926c60b20c0b4b4[m
+Merge: 460015a 90dd976
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 23:41:59 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into hotfix/#188
+
+[33mcommit 460015aed89d136d53947a8fb3c75359877685b3[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 23:41:54 2025 +0900
+
+    fix: AuthServiceImpl 고치는중
+
+[33mcommit 316959d03b0da56ddd50839b74c62f1756c31fc2[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 23:19:10 2025 +0900
+
+    chore: Generation 입력 방식을 label 기반으로 개선
+
+[33mcommit e521d43d0e909a69ebf9aff2b96b7638a62dd713[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 23:06:57 2025 +0900
+
+    chore: 리뷰 내용 반영하여 Swagger 문서 및 인증 관련 설정 정리
+
+[33mcommit 90dd976a57a986ec9cd9cf391a6d881220848c25[m
+Merge: 499a56a d8b4cd2
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sun Dec 7 22:55:24 2025 +0900
+
+    Merge pull request #178 from kjoon418/project-update
+    
+    feat(team building): 프로젝트 수정 API 구현
+
+[33mcommit 3155efb51c543c4dd3d2e9c75a852a036a2c7d1f[m
+Merge: e2fcea6 499a56a
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 22:20:16 2025 +0900
+
+    Merge branch 'main' into feature/#177
+
+[33mcommit 438ed1a8d2c35f0221973b0357c9cf5ffa0c6e27[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 22:11:23 2025 +0900
+
+    refactor(AdminUserProfile) : 병합하면서 누락된 import 추가
+
+[33mcommit ea36323b26e50aaa63edab7c2c63cf06c7d52362[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 22:03:37 2025 +0900
+
+    refactor(AdminUserProfile) : 스웨거 문서 병합 수정
+
+[33mcommit ee306f48c867a33be052df626b1196df4b3a29a7[m
+Merge: 95f197b 499a56a
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 22:02:20 2025 +0900
+
+    Merge branch 'main' into feature/#180
+
+[33mcommit 499a56a9c7707cd1426b8afce6e543af6f090aa9[m
+Merge: 73e177f edf5c14
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sun Dec 7 21:27:40 2025 +0900
+
+    Merge pull request #176 from GDG-on-Campus-SKHU/feature/#175
+    
+    feat(adminUserProfile) : 유저 상세 정보 조회 & 상세 정보 수정 API 구현
+
+[33mcommit 619470055bcc904e2e5d4a2b751cee6c525ee8a4[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 18:25:21 2025 +0900
+
+    hotfix: SingupReqestDto swagger 설명 추가, swaggerconfig servers 등록하는 코드 삭제
+
+[33mcommit f98ad2a8673c45f06bd612f92ad801c3ee330283[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 17:40:22 2025 +0900
+
+    chore: SignUpReqeustDto introduction 삭제
+
+[33mcommit 31e3e65a521b3562fc9dcbbef1ebf875db8fbaf5[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 17:17:35 2025 +0900
+
+    chore: SignRequestDto 주석 제거
+
+[33mcommit 725d684379e7e277eb7651af82126e47ef4a4686[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 17:12:43 2025 +0900
+
+    feat(admin): 기수와 학교명을 기반으로 한 회원 검색 API 구현
+
+[33mcommit 0c6eaff7443a07cb25a690bd20bd2a855ef06d67[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 17:11:29 2025 +0900
+
+    feat(admin): 기수와 학교명을 기반으로 한 회원 검색 API 구현
+
+[33mcommit 22c997d548e0b1964c337510bb7597d2a2184b9a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 16:25:12 2025 +0900
+
+    feat(exception): 전역 예외 핸들러 구현
+
+[33mcommit 583e673ad81bd54e7011ae4311fda705b778958a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 16:03:29 2025 +0900
+
+    refactor(team building): 진행중인 프로젝트 조회 API가 `ProjectTotalResponseDto`를 활용하도록 리팩터링
+
+[33mcommit e65b95324b45344389d17024e58cf5dba5a6229d[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 15:53:33 2025 +0900
+
+    chore(team building): 지원 가능 여부를 멤버로 참여했는지 여부로 판단하도록 개선
+
+[33mcommit 83a3dc35215b49bf16d9923d2e03c9e79ebe2e85[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 15:50:06 2025 +0900
+
+    feat(team building): 지원 API에 검증로직 추가
+
+[33mcommit 79d8b3f792dc91cf5d8193c318802a6b526b4de5[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 15:31:36 2025 +0900
+
+    feat(admin): 관리자용 아이디어 상세 조회 API 구현
+
+[33mcommit 30da7ce36c3783d2f4a46e4bf118e1ecb9fd8208[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 15:13:02 2025 +0900
+
+    feat(admin): 학교 목록 검색 API 구현
+
+[33mcommit efb54423406ea02d7691d39994a95d2bc3f8cbe5[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 14:57:43 2025 +0900
+
+    feat(admin): 프로젝트 삭제 API 구현
+
+[33mcommit 73e177f2906ab929485cdcf6a51a9623f5128428[m
+Merge: b121e6e 0a68dbe
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sun Dec 7 14:32:25 2025 +0900
+
+    Merge pull request #174 from kjoon418/enrollment-validate
+    
+    feat(team building): 프로젝트 조회 API에서 지원 가능 여부도 조회하도록 개선
+
+[33mcommit b121e6eb138423ceabfa77e7ac1b6d113e309784[m
+Merge: e44bebf ec2502d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sun Dec 7 14:31:52 2025 +0900
+
+    Merge pull request #172 from kjoon418/enrollment-scheduler
+    
+    feat(team building): 지원 처리 스케줄러 구현
+
+[33mcommit ec2502dfcea9c80cf1411e667b38adfda2c90850[m
+Merge: c4193a7 e44bebf
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Dec 7 14:31:03 2025 +0900
+
+    Merge branch 'main' into enrollment-scheduler
+
+[33mcommit 6d6e5327b82df12ecb78a8323252e7db2e4ddd46[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 7 13:36:27 2025 +0900
+
+    refactor(s3) : S3 서비스 계층에 인터페이스-구현체 구조 도입
+
+[33mcommit 2238f0732f9ad21b1af3c95780ff713a7e596e2a[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 7 12:57:04 2025 +0900
+
+    docs(swagger) : 이미지 삭제 응답 상태 코드를 204로 변경 및 스웨거 문서의 안내 문구를 직관적으로 수정
+
+[33mcommit 0002a619689d858550a8c2d8bc5e3ed7a28ed904[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 7 12:29:57 2025 +0900
+
+    chore : 잘못된 예외 메세지 수정 및 import 정리
+
+[33mcommit f8250829b03c9b4890370044947226e4da873b42[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Dec 7 12:23:32 2025 +0900
+
+    refactor(s3) : 이미지 업로드 및 삭제 로직 개선
+    
+    - 추가된 환경변수를 .env.example 문서에 기입
+    - 파일 ID로 이미지를 삭제할 수 있도록 수정
+    - 이미지 업로드 및 삭제 요청 API 엔드포인트 RESTful 하게 수정
+    - 서비스 로직의 메서드 모듈화를 통한 가독성 향상
+    - 코드리뷰를 반영해 잘못된 입력을 검증하는 과정 추가
+    - File 객체의 생성자 구조 수정
+    - 서비스 계층에서 이미지 업로드 및 삭제 메서드 실행시 트랜잭션이 수행되도록 수정
+    - 이미지 업로드 및 삭제시 DB에도 변경사항이 반영되도록 수정
+    - 이미지 업로드 로직에서 S3에 업로드는 성공했으나 DB 저장에 실패한 경우 S3에서 이미지를 삭제하도록 수정
+
+[33mcommit e410b2038e7fc914e4d13701dc37576dc91dfabf[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Dec 7 04:38:24 2025 +0900
+
+    hotfix: Swagger 요청 시 403 발생 문제 수정
+
+[33mcommit 1a71c2b855345858fca96b78f8a71e559d169ab2[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 02:32:12 2025 +0900
+
+    feat(Auth): UserStatus 가 BANNED 인 경우 로그인 시도할 떄 LockedException 발생시키도록 처리
+
+[33mcommit 4da517faf92c623c74b3b431c8207f4f49f4d9df[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 01:40:28 2025 +0900
+
+    feat(adminActivity): 서비스 레이어에 액티비티 정보 수정하는 메서드 추가
+
+[33mcommit 3e346c0e5968cd04a3f4b1a6d394f0aa36f0706c[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 01:40:13 2025 +0900
+
+    feat(adminActivity): 스웨거 문서에 액티비티 정보 매서드 추가
+
+[33mcommit 406772e8971172aa88db121a539832fbd79ca20b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 01:39:59 2025 +0900
+
+    feat(adminActivity): 액티비티 정보 매서드 컨트롤러에 추가
+
+[33mcommit a9730d14708e15caccbc7ef8f3adbfff457c67a6[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 01:39:36 2025 +0900
+
+    feat(adminActivity): 액티비티 정보 수정용 dto 추가
+
+[33mcommit 9c7adbcc50fd7683c691ac5bf6faae8c4740df1e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 01:38:51 2025 +0900
+
+    feat(adminUserProfile): 액티비티 도메인에 title, pubulish 수정 메서드 추가
+
+[33mcommit 85e1dea99a23470c5c3b716e4a023678dcf07dbb[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 00:50:54 2025 +0900
+
+    feat(adminUserProfile): 관리자의 셀렉트 데이터 조회용 dto, mapper 추가
+
+[33mcommit 611225bb9b0a7ca6c48fd9d1912418ac5e5ce408[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 00:50:36 2025 +0900
+
+    feat(adminUserProfile): 서비스 레이어에 관리자의 셀렉트 데이터 로드 메서드 추가
+
+[33mcommit 74d62c365c2d1f88240e7e8367e0f3a04b7f91e0[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 00:50:10 2025 +0900
+
+    feat(adminUserProfile): 관리자의 셀렉트 데이터 로드 API 추가
+
+[33mcommit 88e7598a1ba770df1e02c2ac8d465dafc9a2f41e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Dec 7 00:49:39 2025 +0900
+
+    feat(adminUserProfile): 관리자의 셀렉트 데이터 로드 api 스웨거 문서 추가
+
+[33mcommit 81cda384d21fe7893e8332d9ebaa23d1aabae264[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 6 21:00:39 2025 +0900
+
+    refactor(s3) : s3 이미지 API 엔드포인트를 RESTful하게 정리
+
+[33mcommit 42d56e65de91322300f32914a56d1f128a9b9030[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 6 20:41:58 2025 +0900
+
+    docs(env) : .env.example파일에 추가된 환경변수 기입
+
+[33mcommit e7f3e433300775da730f0b6e9e513bd6f81e15f1[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:28:13 2025 +0900
+
+    refactor(domain): 일시 LocalDate 타입으로 변경
+
+[33mcommit 07355a4be0d7927ae4f837e752c211bf94c049c1[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Thu Dec 4 00:11:40 2025 +0900
+
+    ci(cd) : EC2 배포시 aws S3 접근용 환경변수 자동 생성 로직 추가
+
+[33mcommit 0cd885eb685f7bdaf3506a4f6dd44ccfa673d7b3[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Thu Dec 4 00:02:29 2025 +0900
+
+    refactor(s3ImageService) : 허용 확장자 리스트를 불변객체로 변경
+
+[33mcommit 275e8c14f389bce278ccb150094642594983d3af[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 3 23:46:31 2025 +0900
+
+    feat(image) : 이미지 업로드 및 이미지 삭제 기능 구현
+    
+    # Conflicts:
+    #       src/main/java/com/skhu/gdgocteambuildingproject/global/exception/ExceptionMessage.java
+
+[33mcommit d91c002f8c613e3d414b2e1f514a384422bd4e8d[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 20:24:17 2025 +0900
+
+    feat(s3) : s3버킷에 이미지를 업로드하는 로직 개발
+
+[33mcommit 6356160669a5f3f88744cdbd8c349159ef2eb7bc[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 19:35:00 2025 +0900
+
+    chore(s3) : aws s3 의존성 추가 및 application.yml에 필요한 환경변수 생성
+
+[33mcommit 95f197b3cd672e235fd150978bb05693e4554a11[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:57:55 2025 +0900
+
+    feat(adminUserProfile): ExceptionMessage 추가
+
+[33mcommit 93c2e468638652e3ed38d86bc26bb666d7303719[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:57:29 2025 +0900
+
+    refactor(adminUserProfile): 서비스 레이어에 UserGeneration 삭제 메서드 추가
+
+[33mcommit 0197b3bb8fd197d392c358817a701b52c5eb4896[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:56:41 2025 +0900
+
+    refactor(adminUserProfile): 유저의 기수-역할 삭제 메서드 추가
+
+[33mcommit d69d242150cbcbe5b6a67ade11a587d73878c449[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:56:17 2025 +0900
+
+    refactor(adminUserProfile): 유저의 기수-역할 삭제 메서드 스웨거 문서에 추가
+
+[33mcommit e2fcea63cd9abb6107547e46e1b727fbeba3c6a9[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:29:30 2025 +0900
+
+    refactor(adminUserProfile): 프로필 조회 메서드용 dto, mapper 추가
+
+[33mcommit 22298bfe7ba3d9b8183fd0ac3f1567a120e1eb83[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:29:10 2025 +0900
+
+    refactor(adminUserProfile): 서비스 레이어에서 특정 유저의 마이페이지 프로필 조회 메서드 구현
+
+[33mcommit 67023622d09dc8c463f1f8ba91f491bb1e63092f[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 23:28:59 2025 +0900
+
+    refactor(adminUserProfile): 특정 유저의 마이페이지 프로필 조회 기능 구현
+
+[33mcommit d8b4cd2f0f244794481f3cd4e51af9db2603be19[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 6 22:14:10 2025 +0900
+
+    feat(team building): 수정 가능한 프로젝트 조회 API가 참여자에 대한 자세한 정보를 응답하도록 개선
+
+[33mcommit 789f520e6e8b3ecbea59b5629d27ad35fdc641ef[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 6 21:59:06 2025 +0900
+
+    feat(team building): 수정 가능한 조회 API가 멤버 목록도 같이 반환하도록 개선
+
+[33mcommit ac1afd204734365d09152a1c5f862705a6ea7bf0[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 6 21:36:18 2025 +0900
+
+    feat(team building): 프로젝트 수정 API가 참여 인원도 수정하도록 개선
+
+[33mcommit e6578021aa936e9cf699498d2c8150cca007b9a5[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Dec 6 21:28:25 2025 +0900
+
+    feat(team building): 프로젝트 수정 API 구현
+
+[33mcommit e44bebfa099028f9907695bd99e7997b51855555[m
+Merge: e83c933 93f69cb
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 6 21:13:54 2025 +0900
+
+    Merge pull request #170 from kjoon418/project-participant
+    
+    feat(team building): 멤버에 대한 프로젝트 접근 권한 검증 로직 구현
+
+[33mcommit e83c933a56990277033cce405c6393daf19af2b7[m
+Merge: ef88b98 bf573a6
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 6 21:13:42 2025 +0900
+
+    Merge pull request #169 from kjoon418/delete-enrollment
+    
+    feat(team building): 지원 취소 API 구현
+
+[33mcommit ef88b986702c04a34d27763390af7524faa59f28[m
+Merge: da4f8e8 359be1f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Dec 6 21:13:29 2025 +0900
+
+    Merge pull request #167 from kjoon418/read-modifiable-project
+    
+    feat(team building): 수정 가능한 프로젝트 조회 API 구현
+
+[33mcommit da4f8e82c8be96174eec007eae45f40f7b34247f[m
+Merge: c890e34 e98d1fe
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Dec 6 20:02:55 2025 +0900
+
+    Merge pull request #162 from TwooTwoo/feature#145
+    
+    feat(mypage) : IdeaMemberId의 ID를 통해 해당 유저의 프로필을 조회하는 기능 구현
+
+[33mcommit e98d1fe8a0364eb1e3d01fbcd088f0670fca9f0e[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Dec 6 19:44:32 2025 +0900
+
+    chore(ExceptionMessage) : 열거 상수를 파스칼 케이스 형식에 맞게 수정
+
+[33mcommit d5c18246ecf2ec1360bb8f6cc8525c0a1f68dbad[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Wed Dec 3 15:54:58 2025 +0900
+
+    feat(mypage) : IdeaMemberId의 ID를 통해 해당 유저의 프로필을 조회하는 기능 구현
+
+[33mcommit edf5c14c7d16c7120e3ff7c09755ac1abe9f9133[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:43:05 2025 +0900
+
+    refactor(adminUserProfile): 축약된 네이밍 리펙토링
+
+[33mcommit e3535fe8a74375b57bd16a1fd0a40815ef85b59b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:41:27 2025 +0900
+
+    refactor(adminUserProfile): 사용자 상태가 Active일때 banReason 삭제, bannedAt만 빌더에 추가되도록 리펙토링
+
+[33mcommit a91eaa193f38373f1465056323112393bf84e766[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:12:09 2025 +0900
+
+    feat(adminUserProfile): 유저 도메인에 update 메서드 추가 및 deletedAt 타입 Localdate 로 변경
+
+[33mcommit ad5f7535062e82f0ea57cd280cc3d9b096d6f575[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:11:12 2025 +0900
+
+    feat(adminUserProfile): 승인 유저 정보 조회용 ApprovedUserInfoResponseDto 레코드 정의
+
+[33mcommit b7ef71dcab1db36a5d33e95ee55bf26d692bc430[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:01:09 2025 +0900
+
+    feat(adminUserProfile): Deleted, Banned, Active 상태에 따른 DTO 생성 로직을 별도 메서드로 분리
+
+[33mcommit 592cb81b52246ccf9da3bea6709c5fb3781757a6[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:00:39 2025 +0900
+
+    feat(adminUserProfile): 수정 업데이트 dto 추가
+
+[33mcommit d3eb7dc8403cf6b0dd9104838ee4eaff1f1e1d1b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 17:00:15 2025 +0900
+
+    feat(adminUserProfile): 주어진 레이블로 Generation Enum 값 조회하는 fromLabel 메서드 추가
+
+[33mcommit f8367f2a473c8b536afe70f67479eeb30a80af83[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:57:00 2025 +0900
+
+    feat(adminUserProfile): ExceptionMessage 메세지 추가
+
+[33mcommit cc2d8d00eea5cf08a11244f8900285b5e0e0ac7c[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:52:35 2025 +0900
+
+    feat(adminUserProfile): UserStatus에 DELETED 추가
+
+[33mcommit 234732244a0b1f87be50500d92a013b75e6c1ec9[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:51:57 2025 +0900
+
+    feat(adminUserProfile): 기획 변경에 따라 특정 기수-역할 정보가 메인 필드 가지게 추가
+
+[33mcommit d85b8268b0296fa37d52ecc4e943f45bda728530[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:51:18 2025 +0900
+
+    feat(adminUserProfile): 유저 정보 수정용 dto 추가
+
+[33mcommit 8f212707770588dc526292d36f4cb2a7058d8001[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:50:38 2025 +0900
+
+    feat(adminUserProfile): 서비스에 승인된 유저 상세 정보 조회 및 수정 메서드 추가
+
+[33mcommit 9a51598e4da1fb8078dbc9568ea1709d1353d24b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:50:05 2025 +0900
+
+    feat(adminUserProfile): 컨트롤러에 승인된 유저 상세 정보 조회 및 수정 메서드 추가
+
+[33mcommit dbd5c81a3b82c72a7c264801773e47ca56044672[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Dec 6 16:47:07 2025 +0900
+
+    feat(adminUserProfile): 승인된 유저 상세 정보 조회 및 수정 스웨거 문서 추가
+
+[33mcommit 0a68dbe0a78eeafed62c644ab873328fd1ff9533[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 5 14:03:51 2025 +0900
+
+    feat(team building): 프로젝트 조회 API가 지원 가능한 파트 정보도 같이 응답하도록 개선
+
+[33mcommit 137283e7caafc094a6cb898c73d6c1f8d8b9c039[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Dec 5 13:47:13 2025 +0900
+
+    feat(team building): 프로젝트 조회 API에서 지원 가능 여부도 조회하도록 개선
+
+[33mcommit c890e3407296b70622f7633d7b2ae9f3c0d21660[m
+Merge: 29c1db0 3a6a984
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Fri Dec 5 13:28:29 2025 +0900
+
+    Merge pull request #171 from GDG-on-Campus-SKHU/feature/#159
+    
+    feat(domain) : 누락된 일시 로직 추가
+
+[33mcommit 29c1db00fa66d052e540ff3bf81046aaa933c0b7[m
+Merge: a7f4914 3d93579
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Fri Dec 5 13:25:22 2025 +0900
+
+    Merge pull request #158 from GDG-on-Campus-SKHU/feature/#155
+    
+    refactor(domain) : User 엔티티의 Generation와 UserPosition 필드를 단일 문자열에서 Set으로 리팩토링
+
+[33mcommit c4193a7c4a168ace5020ae9d5021bf4dfcc5c3ba[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 4 23:40:23 2025 +0900
+
+    feat(team building): 지원 처리 스케줄러 알고리즘 개선
+
+[33mcommit 078e7792c5e9a4d3c0e15abec1f9a7bbf2e093b0[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 4 18:30:18 2025 +0900
+
+    feat(team building): 지원 처리 스케줄러 구현
+
+[33mcommit 3d9357952eb81ad1a73635a1fffeb42fd47080e1[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:46:23 2025 +0900
+
+    refactor(domain): UserGeneration 필드 nullable false로 변경
+
+[33mcommit 3a6a9842e48a3eee1aed46a3977f0b5ca28148da[m
+Merge: adb97b2 db949e7
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:28:22 2025 +0900
+
+    Merge branch 'main' into feature/#159
+
+[33mcommit adb97b2b3a805d1afdc332be473977caf8acbe4e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:28:13 2025 +0900
+
+    refactor(domain): 일시 LocalDate 타입으로 변경
+
+[33mcommit a1e9d382963fa724645ca2517146c7cfc914d3a3[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:18:43 2025 +0900
+
+    refactor(domain): ban/unban에 대한 일시 코드 로직 추가
+
+[33mcommit 5e704df768db1cbdf91769d829be3a8e9612c418[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:16:15 2025 +0900
+
+    refactor(domain): 가입 일시에 대한 필드 추가 및 로직 변경
+
+[33mcommit 565a46d8f02b1aae9abfa24c0d7e56fb02ff210f[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:11:26 2025 +0900
+
+    refactor(domain): Generation 구조 변경에 따라 테스트 코드 로직 리펙토링
+
+[33mcommit 93f69cb4f83d97a6330fc4474db57a01edaa33d6[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 4 17:08:15 2025 +0900
+
+    feat(team building): 멤버에 대한 프로젝트 접근 권한 검증 로직 구현
+
+[33mcommit 9d5610095c5bdd1c058a9d3c37104d71752f3055[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:01:25 2025 +0900
+
+    refactor(domain): Generation 구조 변경에 따라 mapGenerations, mapPositions 로직 업데이트
+
+[33mcommit 026833a7d5a0d5b1a851c743035d327e5e542e86[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 17:00:51 2025 +0900
+
+    refactor(domain): 회원가입 시 UserGeneration 저장 로직 추가
+
+[33mcommit 2dac01d0d33ee99f4e46e09707ed186ff30d1941[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 16:58:43 2025 +0900
+
+    refactor(domain): UserGeneration 구조 반영하여 generation·position 병합 로직 수정
+
+[33mcommit 089aa4ed11f2c4b5b12a819442f150d44c234665[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 16:57:53 2025 +0900
+
+    refactor(domain): User 엔티티에 @OneToMany(UserGeneration) 연관관계 추가
+
+[33mcommit 4855da1be28a5df9d67b8ea871e381cc8859bd02[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 16:57:22 2025 +0900
+
+    refactor(domain): User 엔티티 generation/position 필드를 단일 값으로 구조 변경
+
+[33mcommit af4d284e7a5d22c0db9314726b12cca403730451[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 16:56:31 2025 +0900
+
+    refactor(domain): Generation 구조 변경에 따라 mapGenerations 로직 업데이트
+
+[33mcommit 766acee74a669e2d2b95aa44f8cf9eea51bd1cc7[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 16:55:25 2025 +0900
+
+    refactor(domain): UserGeneration 레파지토리 추가
+
+[33mcommit 12a21e80c9ea9ce691a0f77b7aa97ace1d7da303[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 16:55:14 2025 +0900
+
+    refactor(domain): UserGeneration으로 네이밍 리펙토링
+
+[33mcommit bf573a6882109ccd8ffb28bb0be5037931adfc62[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 4 16:43:24 2025 +0900
+
+    feat(team building): 지원 취소 API 구현
+
+[33mcommit a7f4914b3c01ac9b933ff00067a00a85abe4a1a3[m
+Merge: 85a28bd bc8cb63
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 4 15:23:42 2025 +0900
+
+    Merge pull request #168 from kjoon418/enrollment-status-enhance
+    
+    feat(team building): 수락 및 거절 예정에 대한 상태 추가
+
+[33mcommit 85a28bdb3c1de2d36de52f6711d302bef45e9627[m
+Merge: d08c1d2 6f49fec
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 4 14:23:49 2025 +0900
+
+    Merge pull request #161 from kjoon418/hotfix-dto
+    
+    fix(dto): DTO의 `getter` 메서드가 Swagger에 필드로 표시되는 문제 수정
+
+[33mcommit d08c1d2c9b542294d650a54b9329a519b1dde269[m
+Merge: 82f11af 13fa909
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 4 14:23:37 2025 +0900
+
+    Merge pull request #160 from kjoon418/fotfix-equals
+    
+    fix(team building): 프록시로 인해 동등 비교에 실패하던 문제 수정
+
+[33mcommit 82f11afaa3e638682217f017735825b1ff73c6f3[m
+Merge: db949e7 d82b079
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Dec 4 14:22:49 2025 +0900
+
+    Merge pull request #147 from kjoon418/idea-delete-enhance
+    
+    feat(team building): 아이디어 삭제 API에 일정 검증 로직 추가
+
+[33mcommit d82b0790ee79ba113c8cb02716579f98c5311d43[m
+Merge: 15d9291 db949e7
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 4 14:20:57 2025 +0900
+
+    Merge branch 'main' into idea-delete-enhance
+
+[33mcommit 359be1f9fb245143ad7034328f91f1aff55331ce[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Dec 4 14:14:43 2025 +0900
+
+    feat(team building): 수정 가능한 프로젝트 조회 API 구현
+
+[33mcommit 40e2df45298ccd399bb11d918d00ad83cfd6b985[m
+Merge: 4590dfc db949e7
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 00:59:47 2025 +0900
+
+    Merge branch 'main' into feature/#155
+
+[33mcommit 4590dfc1b9e9718cd56e2e630b7b25399a4a96bc[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Dec 4 00:50:51 2025 +0900
+
+    refactor(domain): UserGenerationRole 용 도메인 클래스 추가
+
+[33mcommit db949e7d03f8a2f7cb6ef0feef5d3de251a756d8[m
+Merge: a8ee65a 8bc6925
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Wed Dec 3 18:00:31 2025 +0900
+
+    Merge pull request #164 from ggok0265/main
+    
+    fix(config): `SecurityConfig`에 Swagger 경로 설정 복구
+
+[33mcommit 8bc692598dccf424793f37635d1dc41e3d59462e[m
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Wed Dec 3 17:50:04 2025 +0900
+
+    fix(config): `SecurityConfig`에 Swagger 경로 설정 복구
+
+[33mcommit a8ee65a9904ee99f6cd2355081a35951740f8f45[m
+Merge: 274d431 7a72b69
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Wed Dec 3 15:22:41 2025 +0900
+
+    refactor(인증/인가): 이메일 인증 및 비밀번호 재설정 API 문서화 및 예외 처리 개선
+    
+    refactor(인증/인가): 이메일 인증 및 비밀번호 재설정 API 문서화 및 예외 처리 개선
+
+[33mcommit 7a72b6941f3a6ea77fad491d601c89581ed4bbdd[m[33m ([m[1;31morigin/refactor/#124[m[33m, [m[1;32mrefactor/#124[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 3 15:20:53 2025 +0900
+
+    refactor: ResetPasswordController 서비스 계층 이동
+
+[33mcommit 3c39d89fa2334a1e5ca446ab243a16a7e10dda61[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 3 15:11:25 2025 +0900
+
+    refactor: EmailController 서비스 계층 이동
+
+[33mcommit 85df8b684f62704db3b6cc53cafbbc4a3b78d40f[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 3 15:03:21 2025 +0900
+
+    chore: RefreshToken 접근 지정자 private으로 변경
+
+[33mcommit a113c0b7232f3159d4b484d44e370d8da7ef1170[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Dec 3 14:58:38 2025 +0900
+
+    refactor: TokenProvider 예외메세지 통일
+
+[33mcommit 6f49feca60d8f96b466c5fcca540e0da3c329e51[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 3 06:42:49 2025 +0900
+
+    fix(dto): DTO의 `getter` 메서드가 Swagger에 필드로 표시되는 문제 수정
+
+[33mcommit 13fa909f3ca1c0bbcacabe132205dad7b4227123[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Dec 3 06:35:12 2025 +0900
+
+    fix(team building): 프록시로 인해 동등 비교에 실패하던 문제 수정
+
+[33mcommit 274d43158d146b78b5553f87895aba5d723078a8[m
+Merge: 7b37836 9be4d27
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Dec 3 06:19:12 2025 +0900
+
+    Merge pull request #157 from kjoon418/hotpix-schedule
+    
+    fix(team building): 일부 엔티티만 조회하고 있던 문제 수정
+
+[33mcommit a6df1e2574a704acf1b8e6146119d6ff42709e80[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 02:16:56 2025 +0900
+
+    refactor(domain): SignUpRequestDto 마지막 줄 개행 추가
+
+[33mcommit 8769ae69619404abea8467c11d760875975345c3[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 02:13:26 2025 +0900
+
+    refactor(domain): UserInfoMapperTest에서 Generation enum label 기준으로 assertion 수정
+
+[33mcommit ee1f2e4e01b7a6695bdd85616faa9792cdd3af5b[m
+Merge: 1b27410 7b37836
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 02:01:49 2025 +0900
+
+    Merge branch 'main' into feature/#155
+
+[33mcommit 1b274109bf5e5713af7b4ed39ddedeb4c3295efb[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:50:15 2025 +0900
+
+    refactor(domain): 타입 변경에 따른 테스트 코드 리펙토링
+
+[33mcommit dcaf55e62dd1beee38e3643e8c043d84061e7291[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:45:48 2025 +0900
+
+    refactor(domain): UserInfoMapper에서 generation 타입을 리스트로 변경 및 mapGenerations 메서드 추가
+
+[33mcommit 558a8a3bf8c292b5e4ca36fafcbe0a146ba47446[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:45:03 2025 +0900
+
+    refactor(domain): UserResponseDto에서 generation 타입 변경
+
+[33mcommit 5ad3676a9bd49d71de418db575fe16d29ce42f59[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:44:26 2025 +0900
+
+    refactor(domain): User 엔티티에서 generation, position 필드를 String → Enum Set으로 변경
+
+[33mcommit 044147ce8827f3cd547d31b25a83816f83143072[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:35:01 2025 +0900
+
+    refactor(domain): 기존 단일값이었던 generation, position을 set 타입의 복수 값으로 리펙토링
+
+[33mcommit fd2a3e441ba225efe23d0cd9d9ef92ab76cb6a12[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:34:24 2025 +0900
+
+    refactor(domain): 기수용 Generation enum 추가
+
+[33mcommit 3ad9bc030b3eeb88a68087d4904100c69172772f[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:34:05 2025 +0900
+
+    refactor(domain): 타입 변화에 따른 userFromEntity 변환 로직 분리 (joinGenerations, joinPositions 추가)
+
+[33mcommit fcd132fa4dc8dd0754d303d99aa64bdbafdde832[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:22:15 2025 +0900
+
+    refactor(domain): ApprovedUserResponseDto 변환 로직 분리 (mapPositions, mapGenerations 추가)
+
+[33mcommit c2d1b30ddcdbfe6f42e3dd1ed1cdecd12815335f[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Dec 3 01:16:53 2025 +0900
+
+    feat(domain): generation, userPosition 리스트 타입으로 변경
+
+[33mcommit 9be4d27e0acf13a1ed45b40a4ca952806181c02f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 22:06:28 2025 +0900
+
+    fix(team building): 일부 엔티티만 조회하고 있던 문제 수정
+
+[33mcommit 7b3783681e26ea0c4776bd2b6b1e1d873fca28aa[m
+Merge: 4cd5d3e b24079c
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 2 17:48:17 2025 +0900
+
+    Merge pull request #156 from kjoon418/update-idea
+
+[33mcommit 4cd5d3eaea7174ea5cdf13725a745bb1a9865e77[m
+Merge: 86df6ec c860697
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Tue Dec 2 14:58:59 2025 +0900
+
+    Merge pull request #154 from GDG-on-Campus-SKHU/feature/#153
+    
+    feat(adminUserProfile) : REJECTED 상태 회원을 WAITING 상태로 복원하는 API 구현
+
+[33mcommit 86df6ec6e2d8e31b6909ee2e32e68098777e15a8[m
+Merge: ab33b07 38498ce
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Tue Dec 2 14:52:16 2025 +0900
+
+    Merge pull request #152 from GDG-on-Campus-SKHU/feature/#40
+    
+    feat(adminUserProfile) : 승인 완료된 유저 검색 API
+
+[33mcommit d9192dfbc90af0a34ee09be5db46adf0a662d3f7[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Dec 2 14:48:58 2025 +0900
+
+    chore: AuthController 중복 @Tag 제거
+
+[33mcommit b24079cd0c316c73f83657d334513d4734e19d84[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 12:58:02 2025 +0900
+
+    chore(team building): API 명세서에 Enum 값에 대한 설명 추가
+
+[33mcommit 28381aec06dbc84345843ec5b6ac7030f43d0af8[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 12:56:32 2025 +0900
+
+    feat(team building): 아이디어 텍스트 수정 API 구현
+
+[33mcommit f75242ab3f2a9df78699ed1f2a7bea0f362fbbf7[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 12:51:04 2025 +0900
+
+    refactor(team building): 아이디어 수정 요청 DTO의 패키지 경로 수정
+
+[33mcommit cf166de5c7aa0483824ba9e5c2753f998dee209b[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 12:38:58 2025 +0900
+
+    feat(team building): 아이디어 수정(모집 이전) API 구현
+
+[33mcommit 15d9291bcfe977f2d013bb38cfbbbc14263d93cb[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 11:45:40 2025 +0900
+
+    feat(team building): 멤버가 없는 아이디어는 항상 삭제 가능하도록 개선
+
+[33mcommit ab33b070c948bca2f97067fe2ef7dbb51be121b9[m
+Merge: 8e64192 3e3d08d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 2 11:33:54 2025 +0900
+
+    Merge pull request #150 from kjoon418/current-schedule-refactor
+    
+    refactor(team building): 현재 프로젝트/일정 조회 기능 리팩터링
+
+[33mcommit 8e64192d8741d1906f6f180a7f4cfba775071dff[m
+Merge: b2f79bb 38f686d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 2 11:31:10 2025 +0900
+
+    Merge pull request #142 from kjoon418/read-projects-admin
+    
+    feat(admin): 관리자 프로젝트 목록 조회 API 구현
+
+[33mcommit b2f79bb5f4ffa40b56f6c42c0c58da8e92043bde[m
+Merge: a148d07 813fc5e
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Dec 2 11:30:47 2025 +0900
+
+    Merge pull request #139 from kjoon418/restore-idea
+    
+    feat(admin): 관리자용 아이디어 복원 API 구현
+
+[33mcommit 813fc5e6fdeffcfd35077c9c72562ea5ad34fb03[m
+Merge: 861fb3f a148d07
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Dec 2 11:30:20 2025 +0900
+
+    Merge branch 'main' into restore-idea
+
+[33mcommit a148d07aa9a2fe4346a7420ae602fa3cb7686684[m
+Merge: 6cb6e49 acf0cc3
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Dec 1 20:57:11 2025 +0900
+
+    Merge pull request #137 from kjoon418/update-idea-admin
+    
+    feat(admin): 관리자용 아이디어 수정 API 구현
+
+[33mcommit c277b1b7ab9167409afb7f4fd7195aae80faf0b0[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 1 16:19:32 2025 +0900
+
+    feat: 승인 거절된 사용자의 로그인 차단 기능 추가
+
+[33mcommit 54d4007ac0eb85e4c7900f8ddd89d1bb574035bd[m
+Merge: 00828ff 09b6187
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 1 16:12:01 2025 +0900
+
+    Merge branch 'refactor/#122' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into refactor/#124
+
+[33mcommit 00828ff35a3f44b583da30c7e1b53c9a6c9a42ed[m
+Merge: 4eb8a80 6cb6e49
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 1 15:49:41 2025 +0900
+
+    merge: main 브랜치와 merge
+
+[33mcommit c860697a50a0bf2d1cbe134e50e7ed51e57edb2e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 15:34:38 2025 +0900
+
+    feat(adminUserManager): 스웨거 문서에 responseCode 추가
+
+[33mcommit c859fe7686a4ad73d77717e54a63fa7d9b24889a[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 15:32:43 2025 +0900
+
+    feat(adminUserManager): USER_NOT_REJECTED 상태 에러 메세지 추가
+
+[33mcommit 2f6102af77b255d1c4f28c23885371deb1cbfb9b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 15:32:29 2025 +0900
+
+    feat(adminUserManager): 도메인에 누락된 Enumerated 추가 및 resetToWaiting 메서드 추가
+
+[33mcommit 20300365aa9ab6e2b3779806164a6e4959c7efed[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 15:31:44 2025 +0900
+
+    feat(adminUserManager): 서비스 레이어에 이미 REJECTED 유저를 대기 상태로 초기화하는 메서드 추가
+
+[33mcommit ac4bd65d1cb338932e540e80631cb103f375ad32[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 15:31:27 2025 +0900
+
+    feat(adminUserManager): 이미 REJECTED 유저를 대기 상태로 초기화하는 API 추가
+
+[33mcommit 7d4f38f72c651ef7c51c4c4613c27e671b8e5a5c[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 15:30:58 2025 +0900
+
+    feat(adminUserManager): 거부된 회원 상태를 대기중으로 복권하는 스웨거 문서 추가
+
+[33mcommit 4eb8a8013fea4c37f8ed774dfd850528a6de09ca[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Dec 1 15:18:46 2025 +0900
+
+    refactor: refresh token rotation 추가
+
+[33mcommit 38498ceaf91b46d3829d93970365961be2aa748e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 14:41:55 2025 +0900
+
+    feat(adminUserProfile): 승인된 사용자만 검색하도록 Repository 메서드 추가
+
+[33mcommit 2ebbe6081aae597f9380eb62c16a7e7ebd92539e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 14:41:19 2025 +0900
+
+    feat(adminUserProfile): 서비스 인터페이스 및 서비스 레이어에 승인완료된 사용자 검색(학교, 이름, 파트) 메서드 추가 및 공통 메서드 분리
+
+[33mcommit 8e40265bc2c43882167afcb0195769de1276a7df[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 14:40:35 2025 +0900
+
+    feat(adminUserProfile): 승인완료된 사용자 검색(학교, 이름, 파트) API 에 오버라이드 추가
+
+[33mcommit 9d98b4eba9e6310826c30662ff3138633cb72360[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 14:38:49 2025 +0900
+
+    feat(adminUserProfile): 승인완료된 사용자 검색(학교, 이름, 파트) API 추가
+
+[33mcommit e79f70e844513c14390c59fd8fe0d3d0660ed1fa[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Dec 1 14:38:28 2025 +0900
+
+    refactor(adminUserProfile): 승인완료된 사용자 검색 스웨거 문서 추가
+
+[33mcommit 6cb6e49622b68709674cd3d8cd6030a4b210189d[m
+Merge: 25a6211 758340d
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Mon Dec 1 13:46:23 2025 +0900
+
+    Merge pull request #134 from GDG-on-Campus-SKHU/feature/#38
+    
+    feat(adminActivity) : 액티비티의 개별 게시물 & 카테고리 삭제 메서드 추가
+
+[33mcommit 25a62112046f71ded96eb7137d0c240dea4a03d5[m
+Merge: 3fa185b 85634c4
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Mon Dec 1 13:43:24 2025 +0900
+
+    Merge pull request #130 from GDG-on-Campus-SKHU/feature/#41
+    
+    feat(adminProjectgallery) : 관리자 프로젝트 갤러리 프로젝트명 검색 기능 추가
+
+[33mcommit 3fa185bf2186783d5421ef576d8628d2407e31bc[m
+Merge: 2daef68 a57bee4
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Mon Dec 1 13:22:50 2025 +0900
+
+    Merge pull request #128 from ggok0265/main
+    
+    feat(project gallery): 프젝갤의 모델에 대한 테스트 코드 작성 및 프젝갤 코드 정리
+
+[33mcommit 2daef682ff4db55952abfae5ed420305659f15ec[m
+Merge: 88061e3 435d44d
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Dec 1 11:14:31 2025 +0900
+
+    Merge pull request #144 from kjoon418/read-composition
+    
+    feat(team building): 팀원 구성 조회 API 구현
+
+[33mcommit 88061e36b3b4f3ed8eeaca6599af9f69ae59cdc6[m
+Merge: 15af802 f6d48b3
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Dec 1 11:11:04 2025 +0900
+
+    Merge pull request #151 from kjoon418/fotfix-security
+    
+    fix(security): 의존성 문제 해결
+
+[33mcommit f6d48b379f2f72a219947f684e62734f52b14e15[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 1 11:02:00 2025 +0900
+
+    fix(security): 의존성 문제 해결
+
+[33mcommit 3e3d08d76605d0a8b26f58075a617ab314c8fd2b[m
+Merge: 289526a 15af802
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 1 10:54:22 2025 +0900
+
+    Merge branch 'main' into current-schedule-refactor
+
+[33mcommit 435d44d4bcf7a6952e225bb9e4ed97efce9cbe7e[m
+Merge: 2e63606 15af802
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Dec 1 10:36:05 2025 +0900
+
+    Merge branch 'main' into read-composition
+
+[33mcommit 289526a268598e5261429bba2f1f2e8a217e7967[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 1 10:33:21 2025 +0900
+
+    refactor(team building): 현재 프로젝트/일정 조회 기능 리팩터링
+
+[33mcommit 15af80252ff7932cfd964808f84d9f36bde4fc00[m
+Merge: 7e22a7b c0598ec
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Mon Dec 1 10:20:09 2025 +0900
+
+    Merge pull request #136 from TwooTwoo/feature#97
+    
+    feat(mypage) : 마이페이지의 사용자 프로필 조회, 프로필 수정 기능 구현
+
+[33mcommit ab7e89b23cfecc32a25d5fcf7eaef2c925ee6805[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 1 10:03:45 2025 +0900
+
+    feat(team building): 아이디어 삭제 API에 일정 검증 로직 추가
+
+[33mcommit bc8cb63216d34fc5c3a43443971b1d05c7f72afc[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Dec 1 09:49:56 2025 +0900
+
+    feat(team building): 수락 및 거절 예정에 대한 상태 추가
+
+[33mcommit 85634c44fbba7abea514cfeff46707e565e6c391[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Nov 30 22:13:10 2025 +0900
+
+    refactor(adminUserProfile): searchProjectGallery에서 정확히 일치 검색을 LIKE 검색으로 변경
+
+[33mcommit 7e22a7b6913ab6fe09237ed3d369f78fe994839c[m
+Merge: eedf2bb d7bded4
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sun Nov 30 21:52:46 2025 +0900
+
+    Merge pull request #135 from GDG-on-Campus-SKHU/feature/#40
+    
+    feat(adminUserProfile): 사용자 BAN/UNBAN 로직 추가, 정지 계정 로그인/토큰 접근 차단
+
+[33mcommit d7bded4c11c53d01458f7d5cd55b576754b0f510[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Nov 30 21:48:31 2025 +0900
+
+    refactor(adminUserProfile): banUser API 설명 문구 개선
+
+[33mcommit 758340d993a87acea7f6cecea631cabe59c5895d[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Nov 30 21:41:29 2025 +0900
+
+    refactor(adminActivity): 스웨거 문서에서 200 대신 204 응답 문서 수정
+
+[33mcommit 2d44c1db5b9a5cf951a158e4b5c572660d69ab23[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sun Nov 30 21:36:18 2025 +0900
+
+    refactor(adminUserProfile): 스웨거 문서 개행 리펙토링
+
+[33mcommit 2e636065f092bf6fd212793809defbfc3635a7b4[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 30 20:37:16 2025 +0900
+
+    feat(team building): 팀원 구성 조회 API 구현
+
+[33mcommit 38f686dbfa8c98be172ce0e9477cf15ef83125fa[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 30 16:45:31 2025 +0900
+
+    feat(admin): 관리자 프로젝트 목록 조회 API 구현
+
+[33mcommit c5382c5351f7daa15435a79103cc765ad732bbed[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 30 16:43:14 2025 +0900
+
+    chore(team building): `TeamBuildingProject.getCurrentSchedule`에 `null` 방지 로직 추가
+
+[33mcommit 861fb3f303a61c7ffc33a2c3f4607963c564e034[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 30 16:03:41 2025 +0900
+
+    feat(admin): 관리자용 아이디어 복원 API 구현
+
+[33mcommit acf0cc36faf226a3c616f53fdec209b7ba55fbe2[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 30 14:43:25 2025 +0900
+
+    feat(admin): 관리자용 아이디어 수정 API 구현
+
+[33mcommit 3522cbd21171e9f417959fd128f443f227916a41[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 30 14:40:52 2025 +0900
+
+    test(team building): 애플리케이션 코드의 변경사항을 테스트 코드에 반영
+
+[33mcommit c0598ec7310c4935f0a1b244c5a3fd4c6061c2db[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 12:43:10 2025 +0900
+
+    chore(SecurityConfig) : API 경로별 권한 제어 주석 삭제
+
+[33mcommit 88e8517fc2087de3f62fdcea546d9ecc7d4973d9[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 12:39:28 2025 +0900
+
+    refactor(mypage) : 마이페이지 컨트롤러의 인터페이스-구현체 구조를 실제 구현 내용과 일치하도록 수정
+
+[33mcommit ebdafbac0fe5fe3a2e30a7c9e6fc03ddd6fa82e3[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 12:24:53 2025 +0900
+
+    chore(SecurityConfig) : 개발 편의성을 위해 모든 API 요청 허용, 추후 적용할 API 경로별 권한 제어 코드 주석으로 삽입
+
+[33mcommit b7b58408d5096a65b9ad5926e2a5b702941eaec0[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 12:00:04 2025 +0900
+
+    refactor(mypage) : 마이페이지 조회,수정 API에서 URL파라미터 대신 JWT토큰 기반으로 사용자를 식별하도록 변경
+    
+    - SecurityConfig 의 filterChain 메서드에서 모든 요청을 허용하던 로직을 삭제
+    - /mypage/** 경로로 오는 모든 요청은 인증된 사용자만 접근 가능하도록 변경
+    - SecurityConfig의 filterChain 메서드에 JWT토큰을 검증하는 로직 추가
+
+[33mcommit 4f45f68d58aa51be81c55ee5ae01b8d4097608ad[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 02:33:21 2025 +0900
+
+    chore(app.yml-swagger) : Swagger UI의 정렬 순서 변경
+    
+    API(태그) : 가나다순 정렬 이후 알파벳순 정렬
+    태그 안의 메서드 : DELETE - GET - PATCH - POST - PUT
+
+[33mcommit d3828b0b153156823f8f9974d4e4b8d6d9ab5dc2[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 30 02:06:27 2025 +0900
+
+    chore(mypage, config) : 변수명을 직관적으로 수정, POSIX NEW LINE 추가
+
+[33mcommit b308c299aaa432c2041241870cc32a58c5dfb1b1[m
+Merge: 464c0e6 322bcf7
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 29 22:11:58 2025 +0900
+
+    Merge remote-tracking branch 'origin/feature#97' into feature#97
+
+[33mcommit 464c0e6d6fd4b62268b4490767d5c54fd664d47f[m
+Merge: 0c2fa81 eedf2bb
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Nov 29 22:03:14 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into feat#97
+
+[33mcommit 322bcf74f769bd1946b06b4f3df791ea60cde1e8[m
+Merge: 0c3cfe2 eedf2bb
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Nov 29 22:02:30 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into feature#97
+
+[33mcommit 0c2fa81f64f6f7d8d7890989e781eb9afda6ae26[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 29 22:00:13 2025 +0900
+
+    chore(mypage) : 일부 메서드명을 직관적으로 수정
+
+[33mcommit eedf2bbeb3d314190b4a7983321daed58f5d1d8a[m
+Merge: 80aa1ba d9d7b1b
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Nov 29 21:48:27 2025 +0900
+
+    Merge pull request #133 from kjoon418/idea-register
+    
+    feat(team building): 아이디어 등록/조회 로직 개선
+
+[33mcommit 0c3cfe24e3728ae179960494e722f4cce60190bc[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 29 19:24:10 2025 +0900
+
+    fix(mypage) : 프로필 조회 및 수정시 모든 값이 반환되도록 수정, Mypage 네이밍 통일
+
+[33mcommit 1173aed3545187382d5ac931a29a88d3acf5af77[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 29 18:41:15 2025 +0900
+
+    fix(mypage) : 프로필 수정 요청시 기술스택과 링크에 빈 리스트가 올 수 있도록 수정, 기술스택과 링크 ENUM 수정
+
+[33mcommit edeac803b3039c296e4924c633bda5bb92d7d65b[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 29 17:46:51 2025 +0900
+
+    fix(mypage) : 내 프로필에서 학교, 역할, 파트 수정이 불가능하도록 변경 및 계층간 역할 명확하게 분리
+
+[33mcommit ded3cdc2d4fdac578398303ac969d914afe3f138[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 17:20:40 2025 +0900
+
+    refactor(adminUserProfile): 스웨거 문서 description 리펙토링
+
+[33mcommit e10c6e98f9b0ca9fb4bf286c4b25d44f109c9c44[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 17:14:17 2025 +0900
+
+    feat(adminUserProfile): 사용자 BAN 시 사유(reason) 저장 기능 추가
+
+[33mcommit 7775743f4b1e3eb8472006494b909def6a6e6d42[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 17:13:26 2025 +0900
+
+    feat(adminUserProfile): banReason 추가
+
+[33mcommit b09136ee24431fcfaee6c72a1596ebd7b7dc383e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 17:13:10 2025 +0900
+
+    feat(adminUserProfile): 스웨거 문서에도 사유 추가
+
+[33mcommit f07a3567428da997121db2d959e501ac3879c206[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 17:11:37 2025 +0900
+
+    feat(adminUserProfile): 컨트롤러에 ban 사유 dto 추가
+
+[33mcommit e53ef15cb2a29730abc23db616129e1c8968f9b8[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:49:35 2025 +0900
+
+    feat(adminUserProfile): 마지막 줄 개행 추가
+
+[33mcommit 6b91b364b98ab8d0768f258cca375ba7050334d6[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:48:08 2025 +0900
+
+    feat(adminUserProfile): JWT 인증 필터 및 Security 설정 개선, BAN 계정 접근 차단
+
+[33mcommit 756ae8c263004e0ad25e2363aaecc678d14b2a16[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:46:53 2025 +0900
+
+    feat(adminUserProfile): 정지된 회원과 해제 회원 용 exceptionMessage 추가
+
+[33mcommit 4242a7b9d444d7e72304c3c61fb9b3d50fd9c0ee[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:46:26 2025 +0900
+
+    feat(adminUserProfile): 유저 banned 용 UserStatus 추가
+
+[33mcommit 95e268201381a7688df69a8a5f19fe9fb5a00af0[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:46:07 2025 +0900
+
+    feat(adminUserProfile): 로그인할때 유저의 banned 검증 로직 추가
+
+[33mcommit 066ea6ea95717af7af01cf6f8935bbc967debe3d[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:45:42 2025 +0900
+
+    feat(adminUserProfile): 서비스 레이어에 유저 정지 & 정지된 유지 헤재 API 추가 및 트랜젝션 추가
+
+[33mcommit a40d11340a42027837fbf9a588f0c4d591199475[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 16:45:24 2025 +0900
+
+    feat(adminUserProfile): 유저 정지 & 정지된 유지 헤재 API 추가
+
+[33mcommit 340df3b0ade633084c3a6aa25bda17f2ead6e1e8[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 29 12:57:37 2025 +0900
+
+    refactor(mypage) : API 문서화 및 controller,service 계층을 인터페이스와 구현체로 분리
+
+[33mcommit a6a00061efb52871fcd0acc2774e006950b6afd3[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Thu Nov 27 20:32:17 2025 +0900
+
+    feat(mypage) : 프로필 조회 및 수정 기능 구현
+
+[33mcommit a10147cd5a0c3a84896f998e637b766d471c0172[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 00:46:00 2025 +0900
+
+    feat(adminActivity): 서비스 레이어에 개별 게시물 삭제 & 카테고리 삭제 메서드 추가
+
+[33mcommit 50bb1089088af1f8d04b3e081dbcfc25e1c3afe8[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 00:45:09 2025 +0900
+
+    feat(adminActivity): 삭제 메서드 스웨거 문서에 추가
+
+[33mcommit 24f708b756f09f6a71d1f023f7a348cc8f14141b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 00:44:07 2025 +0900
+
+    feat(adminActivity): 개별 게시물 삭제 및 카테고리 삭제 메서드 컨트롤러에 추가
+
+[33mcommit 87018e82e2e91621b73c76313db0446f79f5c7aa[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 29 00:43:31 2025 +0900
+
+    feat(adminActivity): 카테고리 기준 전체 Activity 삭제 쿼리 추가
+
+[33mcommit ca4fee9fdb7db89bd46c2cbb96f17a8c53f7b9ae[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 28 23:35:38 2025 +0900
+
+    refactor: EmailService에 validateEmailExists 추가
+
+[33mcommit d9d7b1bb6b6ba5705818fdec7b51badbb34374b3[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 28 23:14:30 2025 +0900
+
+    feat(team building): `IdeaMemberComposition`에 대한 정보를 조회할 때, 지원 가능한 파트에 대한 정보만 반환하도록 개선
+
+[33mcommit 488c9430431285bf692682f8f0cec5abcc848aa1[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 28 23:10:12 2025 +0900
+
+    chore(team building): `Part`를 통해 `IdeaComposition`을 찾을 수 없을 때 예외를 던지는 대신 기본값을 반환하도록 수정
+
+[33mcommit 935a962f1f08abf5448a80a78ff8fbbc1a1d4dec[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 28 23:04:04 2025 +0900
+
+    feat(team building): `TeamBuildingProject`에 허용된 `Part`에 대한 모집 정보만 구성할 수 있도록 검증
+
+[33mcommit 7863ed02e3fb57183fd8c5228aec58b7f87a3c07[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 28 22:53:09 2025 +0900
+
+    feat(team building): `Idea` 게시자의 `Part`를 `User.part` 대신 `IdeaMember.part`로 대체
+
+[33mcommit c386234826669714610b5115b7695452b48c2c9a[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 28 22:47:07 2025 +0900
+
+    feat(team building): 아이디어 등록자를 `IdeaMember`로 등록
+
+[33mcommit 4a30abca0cc1b350b4e183f1cbf9e7a4fce161b3[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 28 22:31:08 2025 +0900
+
+    feat(team building): 아이디어 등록 기간 검증 로직 추가
+
+[33mcommit 8ffe227b014623797da7c899bd52afa0e8f711db[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 28 21:39:45 2025 +0900
+
+    refactor: ResetPasswordService 생성
+
+[33mcommit 2f892b0286313e32e438c97deb3335acdf17024b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 21:13:58 2025 +0900
+
+    refactor(adminProjectGallery): 불필요한 개행 삭제
+
+[33mcommit fea9997dd1164e7f851d04307d11a32bf70ff883[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 21:13:33 2025 +0900
+
+    refactor(adminProjectGallery): 프로젝트 갤러리 검색 API 파라미터 선언부 간소화
+
+[33mcommit e11e747eae42f61dda9f2a2043390e137772dcd6[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 20:59:40 2025 +0900
+
+    refactor(adminProjectGallery): 스웨거 문서에 파라미터 설명 추가
+
+[33mcommit ef298601258c8d2bbad561f1989fa45640f886d5[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 20:53:01 2025 +0900
+
+    refactor(adminProjectGallery): 프로젝트 갤러리 목록 요청 파라미터 처리 방식 개선
+
+[33mcommit ef967b099957247e0ecfe0b9cbf28e00bd97d54d[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 16:00:45 2025 +0900
+
+    refactor(adminProjectGallery): 검색 메서드 트랜잭션 readonly true로 리펙토링
+
+[33mcommit 5e24cfbb529b04fe1c874cc1c4b0f1e4ac89aefe[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 15:47:00 2025 +0900
+
+    refactor(adminProjectGallery): 관리자 프젝갤 스웨거 API 추가
+
+[33mcommit 937d1acff5208876d237a97efbf2c220f6a8a6a9[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 15:46:44 2025 +0900
+
+    refactor(adminProjectGallery): 변수명을 response로 리펙토링
+
+[33mcommit 80aa1ba1b2236d8cfc0312da59ea35112b0ce9ab[m
+Merge: 442cb98 f24ab93
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Fri Nov 28 15:09:42 2025 +0900
+
+    Merge pull request #129 from GDG-on-Campus-SKHU/feature/#38
+    
+    feat(adminActivity) : 카테고리 목록 반환 & 특정 카테고리의 게시물 목록 조회 API 구현
+
+[33mcommit f24ab93111d441956817f271c34d32a2acd8ebf8[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 15:08:41 2025 +0900
+
+    refactor(adminActivity): 매퍼 메서드 이름 toDto로 리펙토링
+
+[33mcommit db6d8f988a25964544dc52b13d4317286b1314d1[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 15:02:42 2025 +0900
+
+    feat(adminActivity): 컨트롤러에 누락된 @PathVariable 추가
+
+[33mcommit fe1c861d17c7ac9c63a62fec67c312f20eb3df09[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 13:34:49 2025 +0900
+
+    feat(adminProjectGallery): 컨트롤러에 프로젝트 검색 메서드 추가
+
+[33mcommit d10c2a845193c6c449b14a341735988871f93a38[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 13:34:26 2025 +0900
+
+    feat(adminProjectGallery): projectGallery 엔터티를 dto로 변환하는 매퍼 클래스 및 dto 추가
+
+[33mcommit 04e06d06b426c87dce84876c2ab8109648e88f28[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 13:28:36 2025 +0900
+
+    feat(adminProjectGallery): 서비스 인터페이스 추라 및 프로젝트 검색 메서드 추가
+
+[33mcommit 44fe7c8a699c328c0ecdbef04521c4a043a8b824[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Fri Nov 28 13:27:38 2025 +0900
+
+    feat(adminProjectGallery): 프로젝트 명 검색시 정확한 프로젝트만 반환하는 findByProjectName 메서드 추가
+
+[33mcommit 2eb70fbfeca0379de8da698142116a7e487ef1f9[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:16:30 2025 +0900
+
+    refactor(adminActivity): 카테고리 목록 가져오는 메서드를 복수형 네이밍으로 리펙토링
+
+[33mcommit c7abafe05201d46971db7fd0465e26d01308938a[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:10:51 2025 +0900
+
+    feat(adminActivity): 공통 예외 메시지 enum에 CATEGORY_NOT_FOUND 추가
+
+[33mcommit 29b66da493b452989520cd701f5a508d22db0640[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:06:09 2025 +0900
+
+    feat(adminActivity): Activity 엔티티를 DTO로 변환하는 ActivityMapper 추가
+
+[33mcommit 291eb6104cb21825e766e0cbb40c6e7f56a0ed04[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:05:52 2025 +0900
+
+    feat(adminActivity): Activity 응답 정보를 위한 ActivityResponseDto 추가
+
+[33mcommit a1fa01fdd0017a3187ff8c50c21c771fe77c2ab6[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:05:36 2025 +0900
+
+    feat(adminActivity): ActivityRepository에 카테고리별 Activity count 메서드 추가
+
+[33mcommit 218a21bea8d256dc2ef9f03885ae3301db9df0a7[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:04:55 2025 +0900
+
+    feat(adminActivity): 서비스레이어에 카테고리 목록 조회 및 상세 조회 메서드 추가
+
+[33mcommit 5ad2823f57f594aa7e53da6ade801cd24bb55e13[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 22:03:33 2025 +0900
+
+    feat(adminActivity): 컨트롤러에 카테고리 목록 조회 및 상세 조회 메서드 추가
+
+[33mcommit c8c9d6432f031d628c7900fe33a30fe3215e4502[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 21:59:06 2025 +0900
+
+    feat(adminActivity): 스웨거 문서에 카테고리 목록 조회 및 상세 조회 추가
+
+[33mcommit adabfc9af22a4a9dda4638519101478a1383c1da[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 27 21:46:34 2025 +0900
+
+    feat(adminActivity): 액티비티 맵퍼용 클래스 추가
+
+[33mcommit a57bee4fd0fd37429e35bd2ff49e12da6df96f82[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 27 21:43:22 2025 +0900
+
+    refactor(test): 리플렉션으로 작성한 엔티티 Mockito로 수정
+
+[33mcommit 442cb981ebe0b821f58458141329f312165a4165[m
+Merge: 527d501 e7543ac
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 27 21:08:30 2025 +0900
+
+    Merge pull request #119 from kjoon418/enroll
+    
+    feat(team building): 지원 API 구현
+
+[33mcommit e7543ac96309243fc39f9efeb82ef62292117706[m
+Merge: 8c12fa6 527d501
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 27 21:06:41 2025 +0900
+
+    Merge branch 'main' into enroll
+
+[33mcommit 527d5011757d850f59b05c9a6c1c6b996e4ab5a7[m
+Merge: 7383913 d4d6635
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 27 20:57:38 2025 +0900
+
+    Merge pull request #126 from kjoon418/enroll-accept
+    
+    feat(team building): 지원 수락/거절 API 구현
+
+[33mcommit d4d6635b1e3e23766fb4d167ba3e429727b19db6[m
+Merge: 1b74bfa 7383913
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 27 20:55:45 2025 +0900
+
+    Merge branch 'main' into enroll-accept
+
+[33mcommit 73839130e7a226a5209ee8c680de2c7f23de1b6c[m
+Merge: 1d99425 f45d483
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 27 20:37:02 2025 +0900
+
+    Merge pull request #117 from kjoon418/read-creator-enrollment
+    
+    feat(team building): 받은 지원 내역 조회 API 구현
+
+[33mcommit 2484c757c22bcaec46a5c77c2d6a18f584823eda[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 27 15:30:38 2025 +0900
+
+    refactor(project gallery): 전체적인 프젝갤 코드 가독성 및 import 정리
+
+[33mcommit 577951c15edba29021ea32dfc54fcad5571ebee9[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 27 15:19:41 2025 +0900
+
+    feat(test): 프젝갤의 모델에 대한 테스트 코드 작성
+
+[33mcommit 214e5aa4044ac7f98f9030893a2af201821b1742[m
+Merge: 4aa0997 1d99425
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Thu Nov 27 10:14:25 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into main
+
+[33mcommit 1b74bfa94bbcc1adf0bf38d105584da71f426b0d[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 21:00:58 2025 +0900
+
+    chore(team building): 중복된 인원 검증 로직 제거
+
+[33mcommit f5dbaa31985f941d2258ab9551a144a7b213b62e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 20:56:16 2025 +0900
+
+    feat(team building): 지원 수락/거절 API 구현
+
+[33mcommit 1d99425992ab9a39eae979a07adb7a3d33d9123f[m
+Merge: 0341d31 f1b14f1
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Wed Nov 26 18:53:41 2025 +0900
+
+    Merge pull request #115 from ggok0265/main
+    
+    feat(project gallery): 프로젝트 갤러리에 전시되어있는 프로젝트 삭제 기능 구현
+
+[33mcommit 09b618760fec6e0c1078472252cce101e1d58997[m[33m ([m[1;31morigin/refactor/#122[m[33m, [m[1;32mrefactor/#122[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 15:58:14 2025 +0900
+
+    refactor: AuthController @Tag 추가
+
+[33mcommit e742c67b9e4fa203d28b6e3f792e4a6850340415[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 15:53:39 2025 +0900
+
+    feat: EmailController와 ResetPasswordController에 Swagger 문서화 추가
+
+[33mcommit 5106fa4a021e569402d1e9bf36af17268c696e4c[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 15:49:51 2025 +0900
+
+    refactor: 이메일 인증 및 비밀번호 재설정 예외 처리 구조 개선
+
+[33mcommit b2008a0d86f6c9ca3ed36bee237d8d4d97d9349e[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 15:41:27 2025 +0900
+
+    refactor: 주석 제거
+
+[33mcommit d4add40ded618637e479f6057037469d691e2cd6[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 15:31:49 2025 +0900
+
+    chore: build.gradle 오타 수정
+
+[33mcommit 63c690f0e3ff1cd5de588e03d2bba89823077bdb[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 15:26:08 2025 +0900
+
+    refactor: RuntimeException, ExceptionMessage로 예외처리
+
+[33mcommit 26257ff45dfa41e47c626116e8ea5f0e95067c25[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 14:43:12 2025 +0900
+
+    refactor: AuthServiceImpl 예외처리 추가
+
+[33mcommit 89f05b8015dcaca38c1944a1a3dc4b418da8b432[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 14:35:35 2025 +0900
+
+    feat: AuthException 추가
+
+[33mcommit 09d6e7f7d8a0e1db9b1428b84d68cf3e77bd491f[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 26 14:25:19 2025 +0900
+
+    refactor: AuthService와 AuthServiceImpl로 클래스 나누기
+
+[33mcommit dae884e16230bbae59e0f36ebe0af4a9b3a1d9ba[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 13:01:08 2025 +0900
+
+    feat(team building): `IdeaMember`에 빌더 추가
+
+[33mcommit f45d483dfad76dbf67ad2c4021eb2112e55c84bb[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 12:03:30 2025 +0900
+
+    feat(team building): API 명세서에 지원 상태에 대한 정보 추가
+
+[33mcommit ffa149ae5e20a77729c14737a5b9c452bffd3c99[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 12:02:49 2025 +0900
+
+    feat(team building): 지원 상태에 '만료' 추가
+
+[33mcommit 8c12fa6e988a9b9ab4212ef8c840289f98e13190[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 11:26:09 2025 +0900
+
+    feat(team building): 지원 API 구현
+
+[33mcommit 01c137638db67af857ad3fa87a55f5ed363a234c[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 10:32:26 2025 +0900
+
+    feat(team building): 지원 수락 가능 여부도 응답에 포함하도록 개선
+
+[33mcommit c24e3e0f95850f817f12143374612689a6891b7c[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 10:16:13 2025 +0900
+
+    chore(team building): 엔티티 조회 실패에 대한 예외를 `EntityNotFoundException`으로 변경
+
+[33mcommit 5e89e4c57ff5e97534e76112c0c73f7ac6eeda8b[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 10:11:38 2025 +0900
+
+    feat(team building): 받은 지원 내역 조회 API 구현
+
+[33mcommit 6c3f6d49a453b2c11c8e41e229ed4a8e68f8e980[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 09:42:47 2025 +0900
+
+    chore(team building): 지원 내역 DTO 매퍼 이름 변경
+
+[33mcommit 5bebfdfc215e01dca5d6b940e056c6a5c3914715[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 09:29:55 2025 +0900
+
+    chore(team building): 지원 내역 조회 API 엔드포인트 변경
+
+[33mcommit b4ad353ccc84a04c65760a95e9e1a9f136afc7f9[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 09:28:13 2025 +0900
+
+    chore(team building): 지원 내역 조회 관련 메서드명 수정
+
+[33mcommit 35595c3978dea2bdf03ac5f76cb7df9c8faed1d6[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 09:27:13 2025 +0900
+
+    chore(team building): 지원 내역 조회 API의 DTO명 수정
+
+[33mcommit de939b8aecebef7b88ca61e043f0e9ecf9140eb4[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 09:24:42 2025 +0900
+
+    chore(team building): 지원 내역 조회 API의 엔드포인트 변경
+
+[33mcommit 0341d31b08917831481a41f71f1da4834edfdbac[m
+Merge: 87bd2c3 3902bdb
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 26 07:22:23 2025 +0900
+
+    Merge pull request #113 from kjoon418/read-applicant-enrollment
+    
+     feat(domain): 본인의 지원 내역(현황) 조회 API 구현
+
+[33mcommit 3902bdbd6e87ebd6ed52fc372517e7cdb8d905b7[m
+Merge: 8822ed7 87bd2c3
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 26 07:20:50 2025 +0900
+
+    Merge branch 'main' into read-applicant-enrollment
+
+[33mcommit 4aa099728c23b67e150903fae0aaf6ab3a878e1d[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Tue Nov 25 23:47:26 2025 +0900
+
+    feat(mypage) : 마이페이지 구성요소에 기술스택과 링크가 포함될 수 있도록 도메인 추가
+
+[33mcommit a8c89a21340de131b8e23d0d28dfb8045516909d[m
+Merge: 640e8d9 87bd2c3
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Tue Nov 25 22:22:07 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into main
+
+[33mcommit f1b14f18f41ed7300ca7988840298de6c06b02c7[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 25 22:15:25 2025 +0900
+
+    fix(project gallery): 누락된 `@Transactional` 추가
+
+[33mcommit ed7f3b9a869ea83ab7e9d3cefe15368cc4f54216[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 25 22:15:11 2025 +0900
+
+    fix(project gallery): 중복된 코드 삭제
+
+[33mcommit 87bd2c3172ba4442ae926ec833a94889a7f86806[m
+Merge: 8d0cc03 21e99a8
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Tue Nov 25 16:54:53 2025 +0900
+
+    Merge pull request #114 from GDG-on-Campus-SKHU/feature/#38
+    
+    feat(adminActivity) : 액티비티 게시글 생성 및 수정 구현
+
+[33mcommit 248a6898898f4859098c90b6d878df4cef5b797c[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 25 14:49:40 2025 +0900
+
+    refactor(project gallery): 컨트롤러 계층을 Api 문서화 코드로 분리
+
+[33mcommit f0e81de13e3bd54eb6e9a8daf35db22dcdd176b6[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 25 14:29:54 2025 +0900
+
+    feat(project gallery): 프로젝트 갤러리에 전시되어있는 프로젝트 삭제 기능 구현
+
+[33mcommit 21e99a87e0023a0ca199e9f8d4dd8b4f0dc4d594[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:05:14 2025 +0900
+
+    feat(adminActivity): 액티비티 응답용 dto 클래스 추가
+
+[33mcommit 156bae638368f641019ea0107e17fc4bd669ea0c[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:04:52 2025 +0900
+
+    feat(adminActivity): 컨트롤러에서 액티비티 생성 및 게시글 수정 메서드 추가 및 스웨거 api 추가
+
+[33mcommit 25abe479cfccd989192e13476e1210aac7e233a4[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:04:21 2025 +0900
+
+    feat(adminActivity): 액티비티 생성 및 게시글 수정 메서드 추가
+
+[33mcommit c8877d1a24ce27d078997b99fac5a9895b0613d5[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:03:47 2025 +0900
+
+    feat(adminActivity): 예외처리 메세지 추가
+
+[33mcommit c4e7d045ba89e7caadf0b81f08d922606b50d515[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:02:59 2025 +0900
+
+    feat(adminActivity): 액티비티 레파지토리 추가
+
+[33mcommit 06bf60256844f3777490f630d248763238b40f8b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:02:16 2025 +0900
+
+    feat(adminActivity): 액티비티 게시글용 예외처리 클래스 추가
+
+[33mcommit 58c35b151a4f7ef48e6829562f1d53173e423b6b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:02:02 2025 +0900
+
+    feat(adminActivity): 액티비티 게시글의 카테고리 레파지토리 생성
+
+[33mcommit 77dc689af042974294a565b3f86390090bdfa313[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:01:51 2025 +0900
+
+    feat(adminActivity): 액티비티 게시글의 카테고리 테이블 따로 생성
+
+[33mcommit 0dd2a3b005a98896fa8de3fba83673b1cbf293fc[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Mon Nov 24 19:01:03 2025 +0900
+
+    refactor(adminActivity): 기획에 따라 테크톡에서 액티비티로 네이밍 수정 및 빌터 패턴 추가
+
+[33mcommit 640e8d99cc1a4d5d1089077d0535e9629feff624[m
+Merge: 98d4f1f 8d0cc03
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Mon Nov 24 16:51:45 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into main
+
+[33mcommit 8d0cc03bd5aeaff528e8b45adc1efff9f1cc53ef[m
+Merge: c2517f8 f3ffad0
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Nov 24 14:02:50 2025 +0900
+
+    Merge pull request #107 from kjoon418/read-ideas
+    
+    feat(admin): 아이디어 조회 API 구현
+
+[33mcommit c2517f88eabdd66d3286033337bf5369e8a559d5[m
+Merge: f4c05a8 aacc267
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Nov 24 14:02:36 2025 +0900
+
+    Merge pull request #106 from kjoon418/update-project
+    
+    feat(admin): 프로젝트 기간 등록 및 수정 API 구현
+
+[33mcommit 8822ed7019200ae2760b899435427903c2626a63[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 24 13:57:16 2025 +0900
+
+    feat(domain): 본인의 지원 내역(현황) 조회 API 구현
+
+[33mcommit 7642915060d15ad03c9f6a66b9d6e4b1478d4949[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 24 13:55:53 2025 +0900
+
+    feat(domain): 안전한 동등 비교를 위해 BaseEntity에 `id` 기반 `equals`, `hashCode` 재정의
+
+[33mcommit 98d4f1f21588ccdd479b095280e5e4bfccb0fbba[m
+Merge: 40bfbd4 f4c05a8
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Mon Nov 24 13:28:10 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into main
+
+[33mcommit 071d20e0660277cc07b5f8936a1ee78afde3e3da[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 24 13:00:52 2025 +0900
+
+    refactor(team building): 현재 진행중인 프로젝트를 조회하는 책임을 서비스가 아닌 모델에 위임
+
+[33mcommit f3ffad0e2c5c9d7f13a9d69b142d9c8a05c23380[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 24 11:12:10 2025 +0900
+
+    feat(admin): 아이디어 조회 API 구현
+
+[33mcommit aacc267ce3f2aa308cf00c67fb82d864d2069361[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 24 10:30:56 2025 +0900
+
+    feat(admin): 프로젝트 기간 등록 및 수정 API 구현
+
+[33mcommit f4c05a848fb92f7dd0e046859f857c76406b2d75[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Mon Nov 24 01:35:22 2025 +0900
+
+    fix(deploy) : 빌드후 jar 파일을 artifact에 저장한 뒤 deploy 과정에서 이를 사용하도록 수정
+
+[33mcommit 40bfbd4e431be2465d5c5fd5bac7c9d5c4597af9[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Mon Nov 24 01:32:09 2025 +0900
+
+    fix(deploy) : 빌드후 jar파일을 artifact에 저장한 뒤 deploy 과정에서 이를 사용하도록 수정
+
+[33mcommit 405757a5697bd939b050aafa70467fc12e27601b[m
+Author: 윤준석(YunJunSeok) <83647215+junseok0304@users.noreply.github.com>
+Date:   Mon Nov 24 01:23:34 2025 +0900
+
+    application.yml 바인딩 문제 해결
+    
+    application.yml 로 인한 문제 해결
+
+[33mcommit 3b61dae448b1f0dc6e8a9c33f1420b59c52fd165[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Sun Nov 23 11:30:00 2025 +0900
+
+    fix(project gallery): swagger description에 잘못 지정된 마크다운 문법 수정
+
+[33mcommit d064cf19b2737361769d10d37f510e8c32144d67[m
+Merge: 52b0a97 010f4fb
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Nov 22 23:42:33 2025 +0900
+
+    Merge pull request #95 from TwooTwoo/hotfix/#94
+    
+    fix(deploy): swagger 관련 환경변수 주입 오류 수정 #94
+
+[33mcommit 010f4fb1d0eaebac1e7ff4b610287e8a32dc39a8[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 22 23:10:43 2025 +0900
+
+    fix(deploy): swagger 관련 환경변수 주입 오류 수정 #94
+
+[33mcommit 52b0a97e6bbb9ecd3ac6938f22cc9df22e67bcab[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 22 21:18:19 2025 +0900
+
+    build(deploy) : swagger 에서 요구하는 환경변수 값을 deploy.yml에 추가
+    1. SWAGGER_SERVER_LOCAL
+    2. SWAGGER_SERVER_PROD
+
+[33mcommit 7bf2b227ce44450ec060b73f199f624931b4d1ee[m
+Merge: 534561c 049017c
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sat Nov 22 20:57:52 2025 +0900
+
+    Merge pull request #93 from GDG-on-Campus-SKHU/hotfix/#92
+    
+    refactor(config): 스웨거 문서에서 운영 서버와 로컬 서버를 선택할 수 있도록 서버 목록을 등록
+
+[33mcommit 049017c243d301da141274c8b39a090bcefddf95[m[33m ([m[1;31morigin/hotfix/#92[m[33m)[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 22 20:25:14 2025 +0900
+
+    refactor(config): 마지막 줄 개행 추가
+
+[33mcommit 21bd6e183812a7120a667476361205bd4e072cf6[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 22 20:23:38 2025 +0900
+
+    refactor(config): 설정 값 환경 변수화 및 SwaggerProperties 도입
+
+[33mcommit 80feb14147493cfe271d62d7381e950abb6c86a8[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 22 17:15:25 2025 +0900
+
+    refactor(config): 스웨거 문서에서 운영 서버와 로컬 서버를 선택할 수 있도록 서버 목록을 등록
+
+[33mcommit d252e0ac6eddb7cb37e7b6942b5507eea8541e5a[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 22 17:05:46 2025 +0900
+
+    refactor(adminTechTalk): 초기 컨트롤러 및 서비스 세팅
+
+[33mcommit 534561cfdf15b0a1ced46b6589e03cd1452602a4[m
+Merge: a77e88e 255ef2f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Nov 22 13:23:16 2025 +0900
+
+    Merge pull request #91 from kjoon418/read-past-project
+    
+    feat(admin): 관리자용 지난 프로젝트 조회 API 구현
+
+[33mcommit a77e88e1f3e58ac48b63851b7e732b272e5503d9[m
+Merge: 291ae6b b2d9061
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Nov 22 03:53:48 2025 +0900
+
+    Merge pull request #90 from ggok0265/main
+    
+    feat(project gallery): 프로젝트 갤러리에 전시되어있는 프로젝트 수정 API 구현
+
+[33mcommit 291ae6b7b6664a93964a331c1a5eecf8816e5db5[m[33m ([m[1;31morigin/feature/#41[m[33m)[m
+Merge: 7797e5b ff98aa1
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Fri Nov 21 17:42:12 2025 +0900
+
+    Merge pull request #89 from kjoon418/delete-idea
+    
+    feat(admin): 관리자용 아이디어 삭제 API 구현
+
+[33mcommit 255ef2f7945769fcaa09b1ba2a8e46534da00a4c[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Fri Nov 21 15:56:16 2025 +0900
+
+    fix(team building): 잘못된 개행 수정
+
+[33mcommit 5cc31c6a391933d10ca822353bc08ef103a934cd[m
+Merge: 4b20143 7797e5b
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 20 22:17:03 2025 +0900
+
+    Merge branch 'main' into read-past-project
+
+[33mcommit 4b201430a455cc746432100b24d26f7b65940549[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 20 22:13:52 2025 +0900
+
+    refactor(team building): DB 조회 쿼리 개선
+
+[33mcommit d2e3ef0c1c5bf063b88f1c3a5850a1f59b9e88b8[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 20 22:12:43 2025 +0900
+
+    test(team building): `ProjectFilterTest`가 도메인 변경에 영향 받지 않도록 Mockito 기반으로 리팩터링
+
+[33mcommit c394055a71ab20b0d8535ee75f10ebed070b9c0f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 20 21:45:01 2025 +0900
+
+    refactor(team building): `TeamBuildingProject`의 `starDate`와 `endDate` 조회 로직 개선
+
+[33mcommit 7797e5bb7f9b7ceb85d6cf8e2c9a24bbd873b920[m
+Merge: 064c263 6bc3e14
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 20 20:59:17 2025 +0900
+
+    Merge pull request #87 from kjoon418/read-choice
+    
+     feat(team building): 지원하기 정보 조회 API 구현
+
+[33mcommit b2d9061f72bf30288fe99f34809abfa965322ed5[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 20 15:46:32 2025 +0900
+
+    refactor(project gallery): 프로젝트 수정시 `orphanRemoval` 적용하여 컬렉션 기반 삭제로 변경
+
+[33mcommit 01fa19dc3043824c5b312ee09d8f21df1a16526d[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 23:17:21 2025 +0900
+
+    fix(project gallery): 프로젝트 수정시 등록되어 있는 멤버, 파일 삭제 후 재등록하도록 로직 수정
+
+[33mcommit abc9d4bedfb5aeba2ea9fa16bd8230a23f556d88[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 23:10:14 2025 +0900
+
+    refactor(project gallery): `PATCH` 메서드를 `PUT`으로 변경
+
+[33mcommit 37401fe2cbdae1e946664d4c495c989efe07c9bb[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 23:07:47 2025 +0900
+
+    fix(project gallery): 누락된 `@Transactional` 추가
+
+[33mcommit 221963051bdbfca395bb4151eb2969e0751d7843[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 23:07:07 2025 +0900
+
+    fix(project gallery): 잘못 입력된 변수명 수정
+
+[33mcommit 064c263458f51e5d43ade8a5dd51bda737d0762e[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Wed Nov 19 19:12:38 2025 +0900
+
+    docs(env) : env.example 수정
+
+[33mcommit 971d3119ff4c38e18d1a5aa4eb7da2c7d06ca5d5[m
+Merge: 15ee5ea 217e08f
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Wed Nov 19 14:37:51 2025 +0900
+
+    Merge pull request #85 from GDG-on-Campus-SKHU/feature/#37
+    
+    feat(admin userProfile) : 관리자의 승인된 멤버 리스트 조회 & 테스트 코드 리펙토링 진행
+
+[33mcommit 53d1ed6a76071df6803229faec7fd58028af7d61[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 13:49:49 2025 +0900
+
+    refactor(project gallery): dto 패키지 구조 변경
+
+[33mcommit 458f6113c6b79fb2d7bb13b87d47cec2ec477521[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 19 13:49:43 2025 +0900
+
+    feat(admin): 관리자용 지난 프로젝트 조회 API 구현
+
+[33mcommit a03b03c0cfdf2f7f3d6b9bf79ee599d2b0e3bcbf[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 13:32:52 2025 +0900
+
+    feat(project gallery): 프로젝트 갤러리에 전시되어있는 프로젝트 수정 API 구현
+
+[33mcommit ff98aa15c2e2151083d1b9e783cd3568d57389ff[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 19 13:02:55 2025 +0900
+
+    feat(admin): 관리자용 아이디어 삭제 API 구현
+
+[33mcommit 6bc3e14b291f3150c0440a530212e9ae4c095802[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 19 12:24:43 2025 +0900
+
+    feat(team building): 지원하기 정보 조회 API 구현
+
+[33mcommit 217e08fb618ee50754340379ff6b8fbac57a705c[m[33m ([m[1;31morigin/feature/#37[m[33m)[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 10:29:30 2025 +0900
+
+    refactor(adminUserProfile): getApproveAllUsers → getApproveUsers로 메서드명 변경
+
+[33mcommit 28a13090b41221f290936fb2636a79653e1801b4[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 19 10:27:18 2025 +0900
+
+    feat(team building): `Idea` 엔티티 구조 수정
+
+[33mcommit 15ee5ea253c6c16b1fb7163a8428a81058f8d735[m
+Merge: a8f34c7 7771670
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 19 10:08:47 2025 +0900
+
+    Merge pull request #86 from ggok0265/hotfix
+    
+    fix(domain): 경로가 수정되어 사용하지 않는 중복 파일 삭제
+
+[33mcommit a8f34c7079ee75c347e44d789455fa5914f0df5b[m
+Merge: 4d0c96f 3a806b0
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 19 09:39:22 2025 +0900
+
+    Merge pull request #83 from kjoon418/project-read
+    
+    fix(team building): 진행중 혹은 예정된 프로젝트 조회 로직 수정
+
+[33mcommit 0ff5271ef2b83166bda7da3b041b133cb846e54a[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 18 23:33:31 2025 +0900
+
+    feat(project gallery): `@PreAuthorize`를 통한 프로젝트 수정 권한 판독 기능 추가
+
+[33mcommit ea1af102af1ad307752f7d5ac898c5dbdc98a52d[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 18 23:32:18 2025 +0900
+
+    fix(project gallery): 사용하지 않는 파일 삭제
+
+[33mcommit 3a806b0ac78b0d8dfd450c9353966056ded784f5[m
+Merge: 9c2df9d 4d0c96f
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 19 08:37:47 2025 +0900
+
+    Merge branch 'main' into project-read
+
+[33mcommit 4d0c96fb1723d9fd5cf5b897898a7ba45a5b5bd4[m
+Merge: 0a10249 928fee9
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 19 08:35:40 2025 +0900
+
+    Merge pull request #82 from kjoon418/create-project
+    
+    feat(admin): 프로젝트 생성 API 구현
+
+[33mcommit 0a10249a412d6f35ef55c76ae6f65df807bde236[m
+Merge: b637424 a32a59f
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 19 08:35:26 2025 +0900
+
+    Merge pull request #78 from kjoon418/idea-delete
+    
+    feat(team building): 사용자 아이디어 삭제 API 구현
+
+[33mcommit 3b012188e0c0749f50c9fba5d3fa14a5feb394a4[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 02:13:12 2025 +0900
+
+    feat(adminUserProfile): UserRepository 잘못된 병합 리펙토링
+
+[33mcommit 6bea12b94d5e562b38ae6cdffcd5db266ddd71a2[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:56:58 2025 +0900
+
+    feat(adminUserProfile): 테스트 코드에서 유저 빌더에 Part enum으로 리펙토링 진행
+
+[33mcommit 7771670a8c18f02cfc6dee87dc6174dbcac5fec7[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 19 01:56:30 2025 +0900
+
+    fix(domain): 경로가 수정되어 사용하지 않는 중복 파일 삭제
+
+[33mcommit 51621c8047163ee84b734e890eb29b816f5b7d8b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:44:02 2025 +0900
+
+    feat(adminUserProfile): userRepository 병합
+
+[33mcommit 59935607e78bb554c2d4cf60190bafcba6c43d81[m
+Merge: 89c8888 b637424
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:43:25 2025 +0900
+
+    Merge branch 'main' into feature/#37
+
+[33mcommit 89c88889944d555d150279595e68f0f278057110[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:27:59 2025 +0900
+
+    feat(adminUserProfile): 페이징 상수 관리를 스웨거 문서화 인터페이스에게 위임
+
+[33mcommit 880cf4d56310118e14236fe78df277d9e655627d[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:25:13 2025 +0900
+
+    feat(adminUserProfile): 마지막 줄 개행 추가
+
+[33mcommit 7b0c858d8f19f1f4a0a7495c2753f77de1a39b8e[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:20:43 2025 +0900
+
+    feat(adminUserProfile): user 레파지토리에 승인이 완료된 status 유저만 반환되도록 메서드 추가
+
+[33mcommit 395248126e109edad5d2110d9d88b12319d6c1e3[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:20:12 2025 +0900
+
+    feat(adminUserProfile): 데이터 응답용 DTO 추가
+
+[33mcommit 6bfecba0ce15df37aa6d269510c8ac9a3f440041[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:19:36 2025 +0900
+
+    feat(adminUserProfile): AdminUserProfileService 구현체 추가
+
+[33mcommit cab5c13dd6732368f32c7237d66f448e93f2cadc[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:16:45 2025 +0900
+
+    feat(adminUserProfile): AdminUserProfileService 인터페이스 추가
+
+[33mcommit 5793b9bfabdfe340e97b3bf26eb4a1dfc0ded1ff[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:16:19 2025 +0900
+
+    feat(adminUserProfile): 승인된 모든 멤버 프로필 리스트 컨트롤러 스웨거 문서 작성
+
+[33mcommit 1f69c520b82c633857c54c25c7cb2c7a69c04d26[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 19 01:16:05 2025 +0900
+
+    feat(adminUserProfile): 승인된 모든 멤버 프로필 리스트 컨트롤러 API 작성
+
+[33mcommit 928fee967322a5b082ec567024acdc2eb635b54b[m
+Merge: e25a9d4 b637424
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Nov 18 16:02:43 2025 +0900
+
+    Merge branch 'main' into create-project
+
+[33mcommit b6374247f457169bbb2e65522a5c766984367bb8[m
+Merge: 9fbfc13 1ad89af
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Tue Nov 18 14:16:38 2025 +0900
+
+    Merge pull request #84 from ggok0265/restore-lost-commit
+    
+    feat(project gallery): 프로젝트 갤러리에 새로운 프로젝트 전시 API 구현
+
+[33mcommit 1ad89afabdb5aa31fbdc6c7f624fad0901de7788[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 18 14:13:18 2025 +0900
+
+    feat(project gallery): 프로젝트 갤러리에 새로운 프로젝트 전시 API 구현
+
+[33mcommit 9fbfc132dfaf4ab4e189b089972adba9ca5df824[m
+Merge: b9fcc89 cafb758
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Tue Nov 18 01:02:10 2025 +0900
+
+    feat(인증/인가): 회원 탈퇴, swagger 설명 추가
+    
+    feat(인증/인가): 회원 탈퇴
+
+[33mcommit cafb75837882aaee7e0b39fd044823b3cbeb3629[m[33m ([m[1;31morigin/feature/#42[m[33m, [m[1;32mfeature/#42[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 18 00:59:41 2025 +0900
+
+    feat: swagger api 명세서 추가
+
+[33mcommit 38f930ce9ebd063f0b6ce4a8285e2a96cfceceea[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 18 00:57:10 2025 +0900
+
+    feat: deletedAt 추가
+
+[33mcommit a32a59f10b30498a137d7ce8dd240d99cc812223[m
+Merge: cbc9654 b9fcc89
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 17 12:31:36 2025 +0900
+
+    Merge branch 'main' into idea-delete
+
+[33mcommit e25a9d40e7887d401175022077f1f70e86478ed5[m
+Merge: 04e5fa6 b9fcc89
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 17 12:25:47 2025 +0900
+
+    Merge branch 'main' into create-project
+
+[33mcommit b9fcc896fd694ef45e6f3fe02921df016c5bce4f[m
+Merge: 2a50adf c5a4a7c
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Nov 17 12:21:47 2025 +0900
+
+    Merge pull request #71 from kjoon418/registrable
+    
+    feat(team building): 아이디어 등록 가능 여부 조회 기능 추가
+
+[33mcommit c5a4a7cfa1c452b9b0cd62702f5b9bd06434783d[m
+Merge: 8e27b87 2a50adf
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Nov 17 12:21:35 2025 +0900
+
+    Merge branch 'main' into registrable
+
+[33mcommit 9c2df9da9a82abcb85657d7c0fe70be75523ba51[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 16 19:22:32 2025 +0900
+
+    fix(team building): 진행중 혹은 예정된 프로젝트 조회 로직 수정
+
+[33mcommit 2a50adfa6c91926aee891f23b066c0f9428fb6f4[m
+Merge: 18fa6dc 1861f0b
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sun Nov 16 14:18:04 2025 +0900
+
+    Merge pull request #70 from kjoon418/temporary
+    
+    feat(team building): 임시저장된 아이디어 조회 API 구현
+
+[33mcommit 04e5fa6f65ebc02591340e07369bbbdcd9b703b0[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 16 12:39:09 2025 +0900
+
+    feat(admin): 프로젝트 생성 API 구현
+
+[33mcommit 1a1af4426451ab3d8fe6025ddfea7123f31a19c1[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 16 12:18:44 2025 +0900
+
+    refactor(domain): `ProjectSchedule.name`의 자료형을 `String`에서 `ScheduleType`으로 변경 및 이름 수정
+
+[33mcommit db5a045023d1c570aa3295f69b4ac13d36fca548[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 16 12:16:53 2025 +0900
+
+    refactor(exception): `ExceptionMessage` 내 상수 순서 재배치
+
+[33mcommit cbc9654ad13d8bc4187348ada9cde60da1889d85[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 16 11:28:05 2025 +0900
+
+    feat(team building): 사용자 아이디어 삭제 API 구현
+
+[33mcommit d6713e27aece12ab08dab6cdd242983d66f2e684[m
+Merge: 1ab252f 18fa6dc
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Nov 16 01:37:59 2025 +0900
+
+    fix: 중복 코드, 주석, 필요없는 코드 제거
+
+[33mcommit 1ab252f953c6095cda7c0d37be82c009885cc5e5[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Nov 16 01:33:27 2025 +0900
+
+    중복 코드 제거
+
+[33mcommit f1a4d8a372151f26e6881f322363f9b8d8e06744[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Nov 16 00:38:57 2025 +0900
+
+    fix(auth): Soft Delete 적용 및 탈퇴 로직 수정 (email/number null 처리)
+
+[33mcommit b6b45c6b7f2ad04a4026005fe8d7b3daa9a5d975[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Nov 15 23:49:53 2025 +0900
+
+    fix(인증/인가): 중복 코드 제거
+
+[33mcommit 18fa6dcfffbd6df32e43fc9331af9499c837f9f2[m
+Merge: ec40f05 97927c1
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Sat Nov 15 23:05:19 2025 +0900
+
+    Merge pull request #67 from ggok0265/main
+    
+    feat(project gallery): 프젝갤 팀원 등록을 위한 멤버 검색 및 등록 기능 구현
+
+[33mcommit 8e27b87befb35a4d10a740ffcee61d3577253f40[m
+Merge: 71a39ac ec40f05
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Nov 15 23:00:31 2025 +0900
+
+    Merge branch 'main' into registrable
+
+[33mcommit 1861f0be34c0822944de66e5103cbd80c45ec50d[m
+Merge: 367a9fd ec40f05
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sat Nov 15 22:56:44 2025 +0900
+
+    Merge branch 'main' into temporary
+
+[33mcommit ec40f055cdbfcd6d559fcd2f9cadb1187fa1fc17[m
+Merge: b868913 15606ca
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Nov 15 22:47:36 2025 +0900
+
+    Merge pull request #63 from kjoon418/main
+    
+    feat(team building): 아이디어 임시 저장 기능 구현
+
+[33mcommit 15606caff4626bd34b37ff07e04aa14e42d03a2b[m
+Merge: ec1dc8c b868913
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Nov 15 22:46:18 2025 +0900
+
+    Merge branch 'main' into main
+
+[33mcommit b868913178125bcade81b4035a10d074ec9cd666[m
+Merge: 4c63f00 133beaf
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Sat Nov 15 22:43:15 2025 +0900
+
+    Merge pull request #66 from kjoon418/read-ideas
+    
+    feat(team building): 모집 중인 아이디어만 조회 기능 추가
+
+[33mcommit 0fcc8be578396035157c26162069428d228987e5[m
+Merge: afc7d9c 4c63f00
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Nov 15 18:45:24 2025 +0900
+
+    Merge branch 'feature/#42' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into feature/#42
+
+[33mcommit afc7d9c81ca2b86fd30768132095840c9f144d72[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sat Nov 15 18:45:01 2025 +0900
+
+    feat(인증/인가): 회원 탈퇴 구현
+
+[33mcommit 4c63f00a13c61bb4289a6d23b8ed0d55eab0e368[m[33m ([m[1;31morigin/feature/#38[m[33m)[m
+Merge: 3b6c648 216d5df
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Sat Nov 15 18:09:17 2025 +0900
+
+    Merge pull request #60 from GDG-on-Campus-SKHU/feature/#48
+    
+    feat(인증/인가): refreshtoken 구현
+
+[33mcommit 216d5df8340338b53c4d73586306b50c229cb057[m[33m ([m[1;31morigin/feature/#48[m[33m, [m[1;32mfeature/#48[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 14 23:01:47 2025 +0900
+
+    refactor: AuthController Posix New Line 추가
+
+[33mcommit 2e5db8a35138e3c0e407c0e20b748db974658cc4[m
+Merge: 159f99b 3b6c648
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 14 22:59:12 2025 +0900
+
+    merge(domain): User.java 충돌 해결
+
+[33mcommit 97927c1d502e1a5e3c93e5affd6a32340f6998b1[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Nov 14 14:25:59 2025 +0900
+
+    fix(project gallery): `GalleryProjectMember`의 `part`필드 `null` 허용
+
+[33mcommit 9dd6828061a6851f6ed18c5a74316a4174170aa1[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 13 23:56:39 2025 +0900
+
+    fix(exception): 커스텀 예외 클래스 삭제
+
+[33mcommit a241f5cefa910dfd3538118fad28deacefaf88c7[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 13 23:54:03 2025 +0900
+
+    feat(project gallery): 프젝갤 팀원 등록을 위한 멤버 검색 및 등록 기능 구현
+
+[33mcommit 133beafd3eaf72d61682c537a3494e51f9f41327[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 22:43:47 2025 +0900
+
+    chore(team building): 모집 중인 아이디어만 조회 기능 추가
+
+[33mcommit 71a39acd44c238320302524e4c759fc5f940ba51[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 22:12:02 2025 +0900
+
+    feat(team building): 아이디어 등록 가능 여부 조회 기능 추가
+
+[33mcommit 367a9fd8983fa1aa5bd100ec29256aba489fee59[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 21:55:22 2025 +0900
+
+    feat(team building): 임시저장된 아이디어 조회 API 구현
+
+[33mcommit ec1dc8cc51909e8aa10ff1c101dee8c559f45b8f[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 21:53:59 2025 +0900
+
+    chore(team building): 메서드 시그니처의 개행 형식 통일
+
+[33mcommit 587ef5bd4b485ee8f97cd56f9fa71d0efa9e3496[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Thu Nov 13 14:31:56 2025 +0900
+
+    refactor(project gallery): dto 패키지 구조 변경
+
+[33mcommit efcdc66b08e8eec484c175140d6c72411a18d168[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 21:33:08 2025 +0900
+
+    chore(team building): API 명세서 수정
+
+[33mcommit 2539fb1c9fa7eef3b72e2440a4aa6a0260853598[m
+Merge: d530385 3b6c648
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 13 21:26:34 2025 +0900
+
+    Merge branch 'GDG-on-Campus-SKHU:main' into main
+
+[33mcommit d5303850913c47a46e95947fe601619742839a0e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 21:25:57 2025 +0900
+
+    feat(team building): 아이디어 임시 저장 기능 구현
+
+[33mcommit 3b6c64866386964dc80ae843489f8ecdb5b361bd[m
+Merge: 3b34d7e c852a14
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Nov 13 19:02:00 2025 +0900
+
+    Merge pull request #57 from GDG-on-Campus-SKHU/feature/#36
+
+[33mcommit c852a146faea0dadfcce621a3301e75981ebe91c[m[33m ([m[1;31morigin/feature/#36[m[33m)[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 13 18:32:36 2025 +0900
+
+    refactor(adminUserManager): 잘못된 빌드 및 Part enum으로 수정
+
+[33mcommit 7e700fa265dbacdcc249698f6b2a9c113948dbc6[m
+Merge: bb163ff 3b34d7e
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Thu Nov 13 18:25:49 2025 +0900
+
+    Merge branch 'main' into feature/#36
+
+[33mcommit bb163ff7e3772dbb48ff0e5bcd718f96c9631067[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Thu Nov 13 17:50:44 2025 +0900
+
+    refactor(adminUserManager): API 문서에 어노테이션 제거 후 순수 스웨거 명세만 남기도록 리펙토링
+
+[33mcommit 159f99b74e8c3eb3980ed28eb0ff64eab859395e[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 17:36:11 2025 +0900
+
+    refactor: tokenprovider 주석 제거, refreshtoken 수정
+
+[33mcommit 3b34d7eae07047208ca89384bb6f106246d37bb8[m
+Merge: f6e80f3 e72dae1
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 13 17:21:04 2025 +0900
+
+    Merge pull request #59 from kjoon418/main
+    
+    feat(team building): 아이디어 등록 API 구현
+
+[33mcommit 4d1369417ea4ee9b4c5e372a4736079f8ed8b2db[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 17:06:59 2025 +0900
+
+    refactor: refreshtoken domain, repository 생성
+
+[33mcommit e72dae1978cb18f56233c5b03ef94ae954607398[m
+Merge: 2fec730 f6e80f3
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Thu Nov 13 16:30:47 2025 +0900
+
+    Merge branch 'main' into main
+
+[33mcommit 93ed403f40f12598cbf876f0e26b4c7a06a2a9b0[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 16:03:58 2025 +0900
+
+    chore: ExceptionMessage 띄어쓰기 추가
+
+[33mcommit 07ea7b95b37a0d81a3a6020a71fa261ba7903982[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 16:02:07 2025 +0900
+
+    refactor: LoginResponseDto builder로 수정
+
+[33mcommit d00532bd64bf8d534e0f625354be3578f01f6e14[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 15:56:20 2025 +0900
+
+    refactor: 상수화하여 하드코딩된 토큰 만료 배수 제거
+
+[33mcommit 6de6d430c695641b722b53e6db75b71b27c2f43d[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 15:37:20 2025 +0900
+
+    refactor(domain): SignUpRequestDto Part부분 수정
+
+[33mcommit da1deb0e51480f9d232cda77473f335cddef54fc[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 15:31:19 2025 +0900
+
+    refactor(domain): User Part부분 수정
+
+[33mcommit 5efc09753f9919e0dfcbf4979fb129a7334bc425[m
+Merge: 8968cf0 f6e80f3
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 15:28:04 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into feature/#48
+
+[33mcommit f6e80f36c59546c1afb64ea58c97391b777a0a34[m
+Merge: 41b1718 77ecc88
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Thu Nov 13 15:26:58 2025 +0900
+
+    Merge pull request #56 from ggok0265/main
+    
+    feat(project gallery): 프로젝트 갤러리에 등록되어있는 프로젝트 목록 조회 API 구현
+
+[33mcommit 41b1718cc91155a96271952d1a010b233115f29f[m
+Merge: 8ccfe2c 42dba75
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Thu Nov 13 15:25:30 2025 +0900
+
+    refactor(domain): refactor(domain): User파일에 @Builder 추가, AuthService refactor
+    
+    refactor(domain): refactor(domain): User파일에 @Builder 추가, AuthService refactor
+
+[33mcommit 42dba759919cf54d471b79b85f01888dbf6b3b07[m[33m ([m[1;31morigin/feature/#54[m[33m, [m[1;32mfeature/#54[m[33m)[m
+Merge: afbc9a7 8ccfe2c
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 13 15:22:37 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into feature/#54
+
+[33mcommit 2fec7303b636a5572e5ab96dc4acde5cb506db42[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 11:36:55 2025 +0900
+
+    refactor(team building): `IdeaMemberComposition.idea`에 대한 `Setter`를 제거하고 연관관계 주입 방식 변경
+
+[33mcommit a6556c3c97fdb3e7bb7a588ea56d8d7a0b8f9c4e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Thu Nov 13 11:32:09 2025 +0900
+
+    refactor(team building): `IdeaMemberComposition` 생성자의 접근 지정자를 `private`으로 변경
+
+[33mcommit d046a487c63062028bab80679bae5edfb57d673e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 23:27:49 2025 +0900
+
+    feat(team building): 아이디어 게시 API 구현
+
+[33mcommit afbc9a75070cedfae8562ba9a74e106507772cc3[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 12 15:00:28 2025 +0900
+
+    refactor: AuthService 수정
+
+[33mcommit d754db83bb74563b165f607d6059696cda2cb0ac[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 12 14:59:16 2025 +0900
+
+    refactor: SignUpRequestDto에 toEntity 생성
+
+[33mcommit 8968cf05e65b01b1342739f5c574e7edd08662ed[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 12 14:42:07 2025 +0900
+
+    feat: LoginResponseDto, AuthService파일에 refreshtoken 파일 생성
+
+[33mcommit 1dffef59e137d638550209b38f5b967e0cac349c[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 12 14:03:18 2025 +0900
+
+    feat: TokenProvider에 refreshtoken 추가
+
+[33mcommit 78d72fef5043dc9abec0157436309d1ec50dbd7d[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 12 14:02:01 2025 +0900
+
+    feat: User에 refreshtoken추가
+
+[33mcommit 889febb3a7ea185ba66b1f0360280a6c5925c4ad[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 13:05:07 2025 +0900
+
+    refactor(adminUserManager): 인터페이스에 존재하는 상수 중복 선언 제거
+
+[33mcommit 8efbb0e4ead32f168ae85b0d27182e7663c980ff[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 12:04:00 2025 +0900
+
+    refactor(team building): 커스텀 예외를 사용하지 않고 `EntityNotFoundException`을 사용하도록 변경
+
+[33mcommit 77ecc885311f5a3fed20bec0fc63605aa08b5b17[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 12 11:54:03 2025 +0900
+
+    fix(project gallery): `projectList` 네이밍을 `projects`로 변경
+
+[33mcommit 1a3d7eca393828abfea98f56d11ea1fb6970dd5f[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 12 11:41:49 2025 +0900
+
+    style(project gallery): 메서드 체이닝 들여쓰기 적용
+
+[33mcommit 682a0011b11c37665f9e82df7638349e142da503[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 11:35:38 2025 +0900
+
+    chore(team building): 사용하는 Enum 값을 명세서에 명시
+
+[33mcommit 336aef101189bb750fb8c9941914ba0a99f91624[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 11:35:25 2025 +0900
+
+    chore(team building): DTO가 Part.koreanName 대신 Part를 사용하도록 수정
+
+[33mcommit 8ccfe2cc6da83e0087979895a5d621c262e64631[m
+Merge: 8009836 cb468bd
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 12 11:28:10 2025 +0900
+
+    Merge pull request #58 from kjoon418/main
+    
+    fix(exception): 잘못 해결된 Merge Conflict 수정
+
+[33mcommit cb468bd73e0ffcee1808ae5eab088d1be5540fe6[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 11:27:02 2025 +0900
+
+    fix(exception): 잘못 해결된 Merge Conflict 수정
+
+[33mcommit 26934be4448bb85559262f2950ce713bec0c10e9[m
+Merge: f5404e2 8009836
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 11:25:45 2025 +0900
+
+    Merge branch 'main' of https://github.com/kjoon418/25-26-GDGoC-Team-Building-System
+
+[33mcommit f5404e24afaba0a7cd5af9d0ec78a7f318ff5e04[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Wed Nov 12 11:10:16 2025 +0900
+
+    refactor(team building): DTO의 패키지 경로 수정
+
+[33mcommit 8009836c3bcb94763b68e74a2b43fa493d95498c[m
+Merge: cab9872 d81d856
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 12 10:48:56 2025 +0900
+
+    Merge pull request #53 from kjoon418/main
+    
+    feat(team building): 아이디어 상세 조회 API 구현
+
+[33mcommit d81d856e3dfb1f2fb75a187c7a5ed92cb4141801[m
+Merge: 61082a8 cab9872
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Wed Nov 12 10:48:30 2025 +0900
+
+    Merge branch 'main' into main
+
+[33mcommit 671845b8666f03f657c2b1f6a895fffe040cda83[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 08:11:15 2025 +0900
+
+    refactor(adminUserManager): 누락된 엑세스 레벨 추가
+
+[33mcommit c412eab73acb99cdf9a13e2e46f62f7db3a8618b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 02:28:58 2025 +0900
+
+    refactor(adminUserManager): 전체 멤버 조회 경로 수정
+
+[33mcommit da5845866b43480d1699c850f6f29c55c4393966[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 02:20:13 2025 +0900
+
+    refactor(adminUserManager): 마지막줄 공백 추가
+
+[33mcommit f1dff1eb3b8f1f39a95862694a4c7b30f7fb8bd4[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 02:19:03 2025 +0900
+
+    refactor(domain): approved를 enum화에 따라서 로직 변경 및 ApprovalStatus 추가
+
+[33mcommit ad484db7615e12a222cf1a76da93262143b6ff8b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 02:18:11 2025 +0900
+
+    refactor(adminUserManager): 관리자의 멤버 관리 API 추가
+
+[33mcommit 32501b7cc40c83fa0a1d3c65397b51a03ca22be0[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 12 02:14:32 2025 +0900
+
+    refactor(domain): 승인 여부(approved) 필드를 boolean에서 Enum 타입으로 변경
+
+[33mcommit 654f00ec4a4763ba6b54a4592c331d39f637716f[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 12 00:27:58 2025 +0900
+
+    fix(project gallery): 누락된 `@Transactional` 어노테이션 추가
+
+[33mcommit 3b9ec1e0757b66ff6a546c5dcc650f7eb7c157e6[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Wed Nov 12 00:21:31 2025 +0900
+
+    feat(project gallery): 프로젝트 갤러리에 등록되어있는 프로젝트 목록 조회 API 구현
+
+[33mcommit e1364cc5ccdc7bc139f62bd63d84a82399052720[m
+Merge: e9864aa cab9872
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 11 22:48:21 2025 +0900
+
+    Merge branch 'feature/#54' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System into feature/#54
+
+[33mcommit e9864aa55e38e8220c7129a6bffe5df93a0149bd[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 11 22:47:58 2025 +0900
+
+    refactor(domain): User파일에 @Builder 추가, AuthService refactor
+
+[33mcommit cab9872fd17ac8d84b9d42929e3111aeba146ef1[m
+Merge: d03583d 769c113
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Tue Nov 11 21:22:22 2025 +0900
+
+    Merge pull request #52 from ggok0265/main
+    
+    feat(project gallery): 프로젝트 갤러리에 등록되어있는 프로젝트 상세 조회 API 구현
+
+[33mcommit 769c113ec205557a12cc3c700040284463948ff5[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 19:05:24 2025 +0900
+
+    refactor(project gallery): 테스트 코드에서 하드코딩한 값을 상수화하여 사용
+
+[33mcommit 46c0856130aecc7ba0b51b2ee4efd6d8cc07c8b9[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 18:50:51 2025 +0900
+
+    fix(project gallery): `Enum`으로 반환되던 dto를 `String`으로 변경
+
+[33mcommit 61082a817f932129a0faa288eff810ad39ac1ea1[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Tue Nov 11 18:11:31 2025 +0900
+
+    feat(team building): 아이디어 상세 조회 API 구현
+
+[33mcommit c9bcea2ba24dfff01bd20958ef8020f1a1f097cd[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 16:57:55 2025 +0900
+
+    fix(project gallery): 멤버의 'Part` 반환값을 String으로 변경
+
+[33mcommit 4cf4704463e1a082b2de8d2bd071f6eb00b40a58[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 16:54:25 2025 +0900
+
+    feat(domain): `GalleryProjectMember`의 `Part`를 global 패키지 하위에 있는 `Part`로 변경
+
+[33mcommit 4aa4f5e409472b27c51957d36366d64ff9567043[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 16:30:56 2025 +0900
+
+    feat(project gallery): 프로젝트 갤러리에 등록되어있는 프로젝트 상세 조회 API 구현
+
+[33mcommit d0f012b5311a5b6a301b3fc4f265f5ccaf9bb9c6[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 13:56:24 2025 +0900
+
+    chore(domain): nullable=false 제약조건 추가
+
+[33mcommit 14cbd6e94746eec8d65fc48c6b8127f4295e1542[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 13:54:17 2025 +0900
+
+    fix(domain): 모호한 필드명 수정
+
+[33mcommit 14a8b8d4ac72abb0e04f4e05efb313a9cad65e41[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Tue Nov 11 13:52:52 2025 +0900
+
+    fix(domain): 모호한 enum 변수명 수정
+
+[33mcommit d03583d3ec6c434780c4743d977732dc1f38ed60[m
+Merge: 7ebcbb0 34ecae2
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Tue Nov 11 15:45:52 2025 +0900
+
+    Merge pull request #47 from kjoon418/main
+    
+    feat(team building): 아이디어 조회 API 구현
+
+[33mcommit 34ecae2f5e10e7fcb53d7f7fccd9f4b2d3694f5e[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 10 22:35:30 2025 +0900
+
+    refactor(domain): `Part`의 패키지 경로를 global 하위로 변경
+
+[33mcommit c8471fecac22f714bc1fa354a6372267b4756135[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 10 10:51:57 2025 +0900
+
+    feat(team building): 아이디어 조회 API 구현
+
+[33mcommit d7b9c63c7f7e0f3b55da2e944e40b6107815826b[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 10 10:27:15 2025 +0900
+
+    fix(team building): `@Transactional` 애노태이션 누락 수정
+
+[33mcommit 7f4e53841aad7d4ed4155d8be946bca0af14c6f6[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 10 09:23:45 2025 +0900
+
+    fix(domain): 엔티티 구성 수정
+
+[33mcommit 9b3ff6497a1e39bbd5ffe58fdbeb8e62c095a08c[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 10 09:00:55 2025 +0900
+
+    chore(team building): `TeamBuildingService`의 이름을 `ProjectService`로 변경
+
+[33mcommit e51245dcf733ed8e3d5703c87b5b581a0e16aab6[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Mon Nov 10 08:45:12 2025 +0900
+
+    chore(team building): 프로젝트 정보 및 일정 조회 API의 URI 수정
+
+[33mcommit 7ebcbb0cabd92107d8b7862ce9eea21a556f59ae[m
+Merge: 8148932 855fe9e
+Author: Joon Kim <66340263+kjoon418@users.noreply.github.com>
+Date:   Mon Nov 10 06:24:18 2025 +0900
+
+    Merge pull request #46 from kjoon418/main
+    
+    feat(team building): 현재 진행중이거나 예정된 프로젝트 조회 API 구현
+
+[33mcommit 855fe9e0da1ecd3b14c5df96c9142919f05242a4[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 9 15:02:25 2025 +0900
+
+    feat(team building): 현재 진행중이거나 예정된 프로젝트 조회 API 구현
+
+[33mcommit 7dd8079b588c511d63714c504019e6d8099aba2c[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 9 12:36:00 2025 +0900
+
+    feat(global): 예외 메시지를 전역적으로 관리할 객체 추가
+
+[33mcommit 8148932f85f9aeb7185ef6d1129a45764f98116b[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 9 14:57:16 2025 +0900
+
+    build(deploy) : 배포 시 .env 파일을 생성해서 이용하도록 변경
+    - 환경변수 이름을 Spring Boot 자동 설정이 읽는 표준 프로퍼티 키에 맞게 변경
+    - 스프링부트 메일 자동설정이 인식할 수 있도록 application.yml의 spring.mail.name 을 spring.mail.username으로 변경
+    - 그에 따라 MailConfig에 주입되는 프로퍼티 값을 알맞게 수정
+
+[33mcommit 73ca08bee326b90142dbc0b62623d099ab4095f9[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 9 13:16:51 2025 +0900
+
+    build(application) : DB datasource 주소 수정, mail 의 name 키 롤백
+
+[33mcommit 29b4a7be9cbafe9f3761a15141496c9df49ab230[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 9 12:50:01 2025 +0900
+
+    build(deploy) : ECR latest 태그 붙혀 push하도록 설정, mail의 username 키 정정
+
+[33mcommit 2a49cb12ae3ff7ab2abfbf0566b076bec901caeb[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 9 12:21:09 2025 +0900
+
+    chore(domain): `nullable = false` 제약조건 추가
+
+[33mcommit 94ee4bde0b2f61aeaa2783f3f075849a8b4a9019[m
+Author: Kim, Joon <kjoon418@naver.com>
+Date:   Sun Nov 9 12:16:01 2025 +0900
+
+    fix(domain): 잘못 정의된 엔티티 수정
+
+[33mcommit 351331c97dbf43c01a7d3ee8910cd40f92443cc3[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 9 12:11:06 2025 +0900
+
+    build(deploy) : 배포 자동화를 위해 필요한 환경변수 추가 및 환경변수 이름 변경
+
+[33mcommit cfe0e69af6bd2928978ba837f910c004e9dc8f32[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Nov 9 11:39:12 2025 +0900
+
+    build(deploy): deploy.yml·application.yml 수정
+    - GitHub Actions deploy에서 SPRING_DATASOURCE_URL을 시크릿으로 전달하도록 변경
+    - application.yml에서 SPRING_DATASOURCE_URL 우선 사용하게 수정(대체값 포함)
+    - 컨테이너 이름을 teamBuildingSystem-app 으로 통일
+
+[33mcommit 5224440556d7cea32a3ebcd8c70e69d284a5ed9f[m
+Merge: e7a1101 bf4375c
+Author: jihoo kwon <122194700+jihoo2002@users.noreply.github.com>
+Date:   Sun Nov 9 00:05:55 2025 +0900
+
+    Merge pull request #44 from GDG-on-Campus-SKHU/refactor/#43
+    
+    스웨거 문서 추가 및 JWT AccessToken 생성 시 Role 클레임 추가
+
+[33mcommit e7a110107c0e0acc42bd94d1a71a3cf6e7530be1[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Sun Nov 9 00:00:44 2025 +0900
+
+    chore(env): env 파일 형식 추가
+
+[33mcommit bf4375cc807b92e4df58dfed97a07c6482bc53f7[m[33m ([m[1;31morigin/refactor/#43[m[33m)[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 8 21:42:21 2025 +0900
+
+    refactor(#43) :JWT AccessToken 생성 시 Role 클레임 추가
+
+[33mcommit 26b48973dd897339ab1752f3fd07bd25339a5a1b[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 8 21:41:42 2025 +0900
+
+    feat(#43) : Swagger UI 적용을 위해 SwaggerConfig 설정 추가
+
+[33mcommit f422f9f5bca3f906b34621d348389e1e75ddd4b8[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Sat Nov 8 21:40:34 2025 +0900
+
+    chore(#43) : springdoc-openapi-starter-webmvc-ui 2.2.0 의존성 추가
+
+[33mcommit b4e107e112aabf151a0b1c728b86b035fe1869ba[m[33m ([m[1;31morigin/feature/#45[m[33m)[m
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sat Nov 8 20:39:54 2025 +0900
+
+    docs(readme) : readme.md 오타 수정 및 맞춤법 교정
+
+[33mcommit 26faabd9eafe6e6f942c1361f3884bd16effe636[m
+Merge: 96cace3 043a707
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Fri Nov 7 10:41:24 2025 +0900
+
+    Merge pull request #33 from GDG-on-Campus-SKHU/feature/#32
+    
+    비밀번호 재설정(인증/인가)
+
+[33mcommit 043a707b16b5347adbeb5186d684f31239925442[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 10:37:10 2025 +0900
+
+    feat: 비밀번호 재설정(인증/인가)
+
+[33mcommit 96cace3f68dcb78b839142f03ec7a5ad6fb0944c[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 03:06:33 2025 +0900
+
+    fix: 이메일 인증 -> 회원가입한 이메일
+
+[33mcommit 6f3c246fa725f3146186f0c45508be6a12477b21[m
+Merge: ed0945c 5a74f33
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 03:04:35 2025 +0900
+
+    Merge branch 'main' of https://github.com/GDG-on-Campus-SKHU/25-26-GDGoC-Team-Building-System
+
+[33mcommit 5a74f33bb7475b6535e1a83d93003e092cd482b7[m
+Author: Park, Daekyeong <pdk2037@gmail.com>
+Date:   Fri Nov 7 03:03:46 2025 +0900
+
+    Reapply "Feat(#22): 이메일 인증"
+    
+    This reverts commit 1c907886b94723eabf2b11f4180877c86befcfe6.
+
+[33mcommit 2b1f887289f863e1bbaa0651602acc0caa865423[m
+Merge: 475a876 1c90788
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Nov 7 02:42:44 2025 +0900
+
+    Merge pull request #30 from GDG-on-Campus-SKHU/revert-29-feature/#22
+    
+    Revert "Feat(#22): 이메일 인증"
+
+[33mcommit 1c907886b94723eabf2b11f4180877c86befcfe6[m
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Fri Nov 7 02:42:19 2025 +0900
+
+    Revert "Feat(#22): 이메일 인증"
+
+[33mcommit ed0945c3f908163b8ac5043ccd8219775eaf5e84[m[33m ([m[1;31morigin/feature/#22[m[33m, [m[1;32mfeature/#22[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 02:39:27 2025 +0900
+
+    fix: 인증된 이메일만 발송
+
+[33mcommit 475a87659644749f8146dc37bb269c9256a3658d[m
+Merge: ebb25d3 6f5860b
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Fri Nov 7 02:33:11 2025 +0900
+
+    Merge pull request #29 from GDG-on-Campus-SKHU/feature/#22
+    
+    Feat(#22): 이메일 인증
+
+[33mcommit 6f5860bd90c0d8d8f51804cb031a3ceb7c16b7d0[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 02:21:43 2025 +0900
+
+    fix: repository 삭제, emailverification 수정
+
+[33mcommit ade5a8b3bec04b1977324a3be4913cdd0824a389[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 02:19:29 2025 +0900
+
+    feat: config
+
+[33mcommit 188273f53bc991fc924631c3a8a39436907fb905[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 01:09:03 2025 +0900
+
+    EmailController
+
+[33mcommit c141c7464b8fcddeb54cde5b63ce03903d51cbfe[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 01:00:54 2025 +0900
+
+    feat: EmailController
+
+[33mcommit c5802d22a84658f10578ac00936ba9ed8d575a6f[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 00:59:43 2025 +0900
+
+    feat: EmailVerificationRepository
+
+[33mcommit de5e696a02e620cac4dcaaa32448c69f7c936644[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 00:58:52 2025 +0900
+
+    feat: EmailVerifivation
+
+[33mcommit 80a53f65d01e72bdfcafd19aeb22489d0f23d7b6[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 00:57:26 2025 +0900
+
+    feat: EmailService
+
+[33mcommit 463f0c46cf7db34e5a73fcebbc3d64e5a2541666[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Fri Nov 7 00:33:43 2025 +0900
+
+    yml smtp 설정
+
+[33mcommit ebb25d39ea850dcc07c668c002e0179a8025ff4b[m
+Merge: 76dfe14 4f66bd7
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Fri Nov 7 00:15:59 2025 +0900
+
+    Merge pull request #21 from GDG-on-Campus-SKHU/feature/#11
+    
+    Feat(#11): 회원가입/로그인 구현
+
+[33mcommit 4f66bd73195f1d9053060ca550b4cfbc7453f610[m[33m ([m[1;31morigin/feature/#11[m[33m, [m[1;32mfeature/#11[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 6 23:59:26 2025 +0900
+
+    회원가입, 로그인 구현
+
+[33mcommit 76dfe14fc6fd4b2dc7966e83860f7f701f00a7ea[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Thu Nov 6 16:00:57 2025 +0900
+
+    admin 패키지 삭제
+
+[33mcommit e45ce70223bf15944afc6e57cce3f29813ef9d65[m[33m ([m[1;31morigin/feature/#4[m[33m)[m
+Author: Daekyeong Park <pdk02kkw71@naver.com>
+Date:   Thu Nov 6 13:49:28 2025 +0900
+
+    chore: gitignore에 .env 추가
+    
+    README.md에 작성한 내용을 바탕으로 작업시에 .env 파일이 올라갈 위험 방지
+
+[33mcommit 4df32dfe5e4e0670d01bb1366a04ff2870548db6[m
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Wed Nov 5 15:56:31 2025 +0900
+
+    docs(readme) : readme.md 작성
+    
+    - 로컬 환경에서 테스트하는 방법 안내
+
+[33mcommit 6df2536405534df50fc9cee05ef4fd545855c8f5[m
+Author: jihoo2002 <yolohoo@naver.com>
+Date:   Wed Nov 5 15:46:19 2025 +0900
+
+    chore: 협업을 위한 이슈 및 PR 템플릿 추가
+
+[33mcommit 02d37c4e72007f80282c721a48ce2ee971faefaa[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Wed Nov 5 15:18:15 2025 +0900
+
+    chore(env) : application.yml 작성 및 gitignore에서 제외, .env.example 추가
+
+[33mcommit 22d6d504e4b30f6eee480cb9e6fc2a9f09d74008[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Wed Nov 5 14:24:14 2025 +0900
+
+    build(dockerfile) : Docker 빌드 시 사용하는 JDK 종류를 OpenJDK에서 Eclipse Temurin으로 변경
+
+[33mcommit de6f756d8b0e84c1c6ff7cdaa1ec384b26efe60d[m[33m ([m[1;31morigin/feature/#3[m[33m, [m[1;32mfeature/#3[m[33m)[m
+Merge: 6eab7a0 ae6e94b
+Author: Bomin Kim <139671172+bomin0214@users.noreply.github.com>
+Date:   Wed Nov 5 13:42:01 2025 +0900
+
+    Merge pull request #2 from GDG-on-Campus-SKHU/feature/#1
+    
+    Feature/#1
+
+[33mcommit ae6e94bb6307185db9662228b84730bdc72ff4fb[m[33m ([m[1;31morigin/feature/#1[m[33m, [m[1;32mfeature/#1[m[33m)[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Wed Nov 5 13:41:26 2025 +0900
+
+    fix/#1 name 최대5글자
+
+[33mcommit 9486ddd8a935ec8bec0e1c03e87ad008a0046595[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 4 17:17:26 2025 +0900
+
+    fix/#1 BaseEntity id 추가
+
+[33mcommit 93e98c3d54612d2c6d632fa4000481b2494f6b0b[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 4 17:01:47 2025 +0900
+
+    feat/#1 user 제약조건 추가
+
+[33mcommit e4974386f365bcf6e0ca9f7d46c63a151df0dec9[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Tue Nov 4 16:11:33 2025 +0900
+
+    feat/#1 baseEntity추가
+
+[33mcommit c08fbc02b4099b997165999e8ee04c67b0070dd4[m
+Author: bomikim0214 <rlaqhals05@naver.com>
+Date:   Mon Nov 3 17:16:26 2025 +0900
+
+    feat/#1 도메인 생성
+
+[33mcommit 6eab7a0075bd6a99cba3281ea90740c98459663f[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 1 13:10:28 2025 +0900
+
+    fix(build.gradle) : build.gradle의 toolchain 설정으로 인해 jdk17버전이 강제되던 것을 jdk21이 강제되도록 수정
+
+[33mcommit 156a4056e21563b6fe16806af2e7510935a0e9d5[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 1 12:29:30 2025 +0900
+
+    CI : Github Actions의 CI 과정에서 발생한 빌드 실패 트러블슈팅
+    - deploy.yml 파일의 jobs-build-name 의 Set up 을 Setup으로 수정
+    - .gitignore 에서 gradle/wrapper/gradle-wrapper.jar 파일 제외
+    - 추후 빌드시 오류 로그 확인을 위해 CI과정의 빌드 명령어를 RUN ./gradlew build -x test --stacktrace로 변경
+
+[33mcommit 8cc9b0f7c87ce1bfef25d987277e449ac28e0389[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 1 12:06:13 2025 +0900
+
+    CI(deploy.yml) : Github Actions를 통한 빌드 진행시 jdk21을 사용하도록 deploy.yml 수정
+
+[33mcommit 72c03140ce273071f6257b7eeabedde83fb92f0d[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sat Nov 1 11:59:05 2025 +0900
+
+    build(dockerfile) : 도커 컨테이너 빌드 및 런타임 환경에서 jdk21을 사용하도록 dockerfile 수정
+
+[33mcommit c4a21ad88abc833a24bc2cfae03ce12beb388e71[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Oct 26 23:12:18 2025 +0900
+
+    feat: Dockerfile 추가로 빌드 환경 구성
+
+[33mcommit 570357f497ac64e2479c6aad82cb2de8809f2313[m
+Author: Taewoo Kim <38293268+TwooTwoo@users.noreply.github.com>
+Date:   Sun Oct 26 22:31:45 2025 +0900
+
+    ci : Gradle build 및 EC2 자동 배포를 위한  CI/CD 파이프라인 추가
+    
+    main 브랜치 push시 Gradle빌드 - ECR푸시 -  EC2배포 자동화
+
+[33mcommit 88fd71b1d97c7adf17c6da7ebfddb7b746b35b1a[m
+Author: TwooTwoo <mbnman12@gmail.com>
+Date:   Sun Oct 26 22:01:58 2025 +0900
+
+    init: 팀빌딩 프로젝트 스프링부트 프로젝트 생성

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/cookie/RefreshTokenCookieWriter.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/cookie/RefreshTokenCookieWriter.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenCookieWriter {
-
     private final TokenService tokenService;
 
     public void write(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/skhu/gdgocteambuildingproject/auth/domain/RefreshToken.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/auth/domain/RefreshToken.java
@@ -29,7 +29,7 @@ public class RefreshToken extends BaseEntity {
         this.expiredAt = expiredAt;
     }
 
-    public static RefreshToken of(User user, String token, LocalDateTime expiredAt) {
+    public static RefreshToken create(User user, String token, LocalDateTime expiredAt) {
         return new RefreshToken(user, token, expiredAt);
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/TokenProvider.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/jwt/TokenProvider.java
@@ -26,6 +26,7 @@ import java.util.Date;
 public class TokenProvider {
     private static final String ROLE_CLAIM = "Role";
     private static final String TOKEN_TYPE_CLAIM = "tokenType";
+    private static final String JTI_CLAIM = "jti";
     private static final String ACCESS_TOKEN = "ACCESS";
     private static final String REFRESH_TOKEN = "REFRESH";
 
@@ -54,6 +55,7 @@ public class TokenProvider {
                 .setSubject(user.getId().toString())
                 .claim(ROLE_CLAIM, user.getRole().name())
                 .claim(TOKEN_TYPE_CLAIM, ACCESS_TOKEN)
+                .claim(JTI_CLAIM, java.util.UUID.randomUUID().toString())
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(key, SignatureAlgorithm.HS256)
@@ -67,6 +69,7 @@ public class TokenProvider {
         return Jwts.builder()
                 .setSubject(user.getId().toString())
                 .claim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN)
+                .claim(JTI_CLAIM, java.util.UUID.randomUUID().toString())
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(key, SignatureAlgorithm.HS256)


### PR DESCRIPTION
## 📝 PR 설명
> refresh 요청 시 Access Token과 Refresh Token을 동시에 재발급하여 버그 해결

## 🔍 관련 이슈
- #346 

## ✅ TODO
- [x]  refresh 요청 시 access / refresh 토큰 동시 재발급
- [x] 기존 refresh token 즉시 폐기 및 DB 기반 상태 관리
- [x] Access / Refresh Token 모두 jti 클레임을 추가하여 토큰 중복 발급 방지
- [x] Refresh Token을 HttpOnly Secure Cookie로 관리하도록 로직 정리

## 기타
| 구분 | Access Token | Refresh Token |
| --- | --- | --- |
| 일반 API | ⭕ 허용 | ❌ 차단 |
| `/auth/refresh` | ❌ 차단 | ⭕ 허용 |
| `/auth/logout` | ❌ 차단 | ⭕ 허용 |
| `/auth/delete` | ❌ 차단 | ⭕ 허용 |
| 필터 인증 | ⭕ | ⭕ |
| 최종 권한 판단 | 경로 기준 | 경로 기준 |
