### PR TITLE
feat(admin): 프로젝트 정보를 수정할 때, 모집 마감 일정을 초기화하도록 개선

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminProjectManageApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/api/AdminProjectManageApi.java
@@ -73,6 +73,8 @@ public interface AdminProjectManageApi {
                     프로젝트를 수정합니다.
                     발표 일정(`ANNOUNCEMENT`)의 endAt 값은 null이어야 합니다.
                     
+                    발표 일정은 수정시 초기화되므로, 해당 일정에 대한 팀빌딩 지원을 다시 처리할 수 있는 상태가 됩니다.
+                    
                     part: PM, DESIGN, WEB, MOBILE, BACKEND, AI
                     
                     scheduleType: IDEA_REGISTRATION, FIRST_TEAM_BUILDING, FIRST_TEAM_BUILDING_ANNOUNCEMENT, SECOND_TEAM_BUILDING, SECOND_TEAM_BUILDING_ANNOUNCEMENT, THIRD_TEAM_BUILDING, FINAL_RESULT_ANNOUNCEMENT

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectSchedule.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/ProjectSchedule.java
@@ -79,6 +79,10 @@ public class ProjectSchedule extends BaseEntity {
     ) {
         validateDates(startDate, endDate);
 
+        if (type.isAnnouncement()) {
+            confirmed = false;
+        }
+
         this.startDate = startDate;
         this.endDate = endDate;
     }


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

현재 구현으로는 모집 마감 일정은 단 한번만 동작하므로, 한 번 날짜를 잘못 설정했을 경우 필요할 때 동작하지 않는 문제가 있었습니다.
날짜를 수정할 때 마다 모집 마감 일정의 상태가 초기화되어, 다시 모집 마감 로직을 처리할 수 있는 상태가 되도록 개선했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.