### PR TITLE
feat(team building): 아이디어 생성 API에서, maxCount를 0으로 설정한 파트는 모집 가능한지 검증하지 않도록 개선

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -602,7 +602,11 @@ public class IdeaServiceImpl implements IdeaService {
             Idea idea,
             List<IdeaMemberCompositionRequestDto> compositions
     ) {
-        for (IdeaMemberCompositionRequestDto composition : compositions) {
+        List<IdeaMemberCompositionRequestDto> recruitingCompositions = compositions.stream()
+                .filter(composition -> composition.maxCount() > 0)
+                .toList();
+
+        for (IdeaMemberCompositionRequestDto composition : recruitingCompositions) {
             Part part = composition.part();
             int maxCount = composition.maxCount();
 


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

아이디어 생성 시점에, maxCount가 0인 파트는 프로젝트에서 모집하지 않는 파트여도 정상 처리하도록 개선했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.