### PR TITLE
feat(admin): 대시보드에서 진행중인 프로젝트 일정의 마감기한 조회 로직 개선

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/dashboard/ProjectSummaryResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/dto/dashboard/ProjectSummaryResponseDto.java
@@ -1,5 +1,6 @@
 package com.skhu.gdgocteambuildingproject.admin.dto.dashboard;
 
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -11,7 +12,7 @@ public record ProjectSummaryResponseDto(
         int ideaCount,
         int currentParticipants,
         int maxMemberCount,
-        String currentScheduleType,
+        ScheduleType currentScheduleType,
         LocalDateTime currentScheduleDeadline
 ) {
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/ProjectSummaryMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/model/ProjectSummaryMapper.java
@@ -1,30 +1,51 @@
 package com.skhu.gdgocteambuildingproject.admin.model;
 
 import com.skhu.gdgocteambuildingproject.admin.dto.dashboard.ProjectSummaryResponseDto;
-import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectSchedule;
-import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.ScheduleType;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
+import com.skhu.gdgocteambuildingproject.teambuilding.model.ProjectUtil;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-
 @Component
+@RequiredArgsConstructor
 public class ProjectSummaryMapper {
 
+    private final ProjectUtil projectUtil;
+
     public ProjectSummaryResponseDto toSummaryResponse(TeamBuildingProject project) {
-        ProjectSchedule currentSchedule = project.getCurrentSchedule().get();
+        return project.getCurrentSchedule()
+                .map(schedule -> map(project, schedule))
+                .orElseGet(() -> mapWithUpcomingSchedule(project));
+    }
 
-        ScheduleType type = currentSchedule.getType();
-        LocalDateTime deadline = currentSchedule.getEndDate();
-
+    private ProjectSummaryResponseDto map(TeamBuildingProject project, ProjectSchedule schedule) {
         return ProjectSummaryResponseDto.builder()
                 .id(project.getId())
                 .projectName(project.getName())
                 .ideaCount(project.getIdeas().size())
                 .currentParticipants(project.getParticipants().size())
                 .maxMemberCount(project.getMaxMemberCount())
-                .currentScheduleType(type.name())
-                .currentScheduleDeadline(deadline)
+                .currentScheduleType(schedule.getType())
+                .currentScheduleDeadline(getDeadline(project, schedule))
                 .build();
+    }
+
+    private ProjectSummaryResponseDto mapWithUpcomingSchedule(TeamBuildingProject project) {
+        return projectUtil.findUpcomingSchedule(project)
+                .map(upcomingSchedule -> map(project, upcomingSchedule))
+                .orElse(null);
+    }
+
+    private LocalDateTime getDeadline(TeamBuildingProject project, ProjectSchedule schedule) {
+        if (schedule.getEndDate() == null) {
+            // endDate가 null일 경우, 다음 일정의 시작일을 현재 일정의 마감일로 취급
+            return project.getNextScheduleOf(schedule.getType())
+                    .map(ProjectSchedule::getStartDate)
+                    .orElse(null);
+        }
+
+        return schedule.getEndDate();
     }
 }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/admin/service/AdminDashboardServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/admin/service/AdminDashboardServiceImpl.java
@@ -7,6 +7,7 @@ import com.skhu.gdgocteambuildingproject.admin.model.ProjectSummaryMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.repository.TeamBuildingProjectRepository;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.ApprovalStatus;
 import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,8 +34,8 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
         long countByApprovalUser = userRepository.countByApprovalStatus(ApprovalStatus.APPROVED);
 
         List<ProjectSummaryResponseDto> activeProjects = teamBuildingProjectRepository.findAll().stream()
-                .filter(p -> p.getCurrentSchedule().isPresent())
                 .map(projectSummaryMapper::toSummaryResponse)
+                .filter(Objects::nonNull)
                 .toList();
 
         return dashboardResponseMapper.toDashboardResponse(

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
@@ -180,6 +180,18 @@ public class TeamBuildingProject extends BaseEntity {
                 .findAny();
     }
 
+    public Optional<ProjectSchedule> getNextScheduleOf(ScheduleType scheduleType) {
+        if (scheduleType == null) {
+            return Optional.empty();
+        }
+
+        ScheduleType nextScheduleType = scheduleType.getNextScheduleType();
+
+        return schedules.stream()
+                .filter(schedule -> schedule.getType() == nextScheduleType)
+                .findAny();
+    }
+
     public ProjectSchedule getScheduleFrom(ScheduleType scheduleType) {
         return schedules.stream()
                 .filter(schedule -> schedule.getType() == scheduleType)

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
@@ -41,6 +41,17 @@ public class ProjectUtil {
         return currentProject.getCurrentSchedule();
     }
 
+    public Optional<ProjectSchedule> findUpcomingSchedule(TeamBuildingProject project) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 이후에 시작하는 일정 중 가장 빠른 일정을 반환
+        return project.getSchedules().stream()
+                .filter(ProjectSchedule::isScheduled)
+                .filter(schedule -> schedule.getStartDate() != null)
+                .filter(schedule -> schedule.getStartDate().isAfter(now))
+                .min(Comparator.comparing(ProjectSchedule::getStartDate));
+    }
+
     private List<TeamBuildingProject> findUnfinishedProjects() {
         // 아직 마지막 일정이 끝나지 않은 프로젝트들만 조회
         return projectRepository.findProjectsWithScheduleNotEndedBefore(


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

발표 일정의 `endDate`가 `null`일 수 있으므로, `endDate`가 `null`일 경우에는 다음 일정의 `startDate`를 데드라인으로 설정합니다.
현재 일정이 없는 경우에도, 그 다음에 오는 일정을 통해 DTO를 생성하도록 구현합니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.