### PR TITLE
feat(admin): 아이디어 등록시 필요한 데이터를 응답하는 API 구현

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/IdeaController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/controller/IdeaController.java
@@ -6,6 +6,7 @@ import com.skhu.gdgocteambuildingproject.global.pagination.SortOrder;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaCreateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaTextUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaUpdateRequestDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaConfigurationResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaDetailInfoResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaTitleInfoPageResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.RosterResponseDto;
@@ -62,6 +63,27 @@ public class IdeaController {
         long userId = getUserIdFrom(principal);
 
         TemporaryIdeaDetailResponseDto response = ideaService.createIdea(projectId, userId, requestDto);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/projects/current/ideas/configurations")
+    @Operation(
+            summary = "아이디어 등록 설정(조건) 조회",
+            description = """
+                    현재 진행중인 프로젝트에서 아이디어 등록시 요구하는 조건을 조회합니다.
+                    
+                    주제 목록, 모집 가능 파트, 팀 최대 인원수를 응답합니다.
+                    
+                    part: PM, DESIGN, WEB, MOBILE, BACKEND, AI
+                    """
+    )
+    public ResponseEntity<IdeaConfigurationResponseDto> findIdeaConfiguration(
+            Principal principal
+    ) {
+        long userId = getUserIdFrom(principal);
+
+        IdeaConfigurationResponseDto response = ideaService.findIdeaConfiguration(userId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/idea/IdeaConfigurationResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/idea/IdeaConfigurationResponseDto.java
@@ -1,0 +1,15 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.dto.idea;
+
+import com.skhu.gdgocteambuildingproject.global.enumtype.Part;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.project.ProjectTopicResponseDto;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record IdeaConfigurationResponseDto(
+        List<ProjectTopicResponseDto> topics,
+        List<Part> availableParts,
+        Integer maxMemberCount
+) {
+}
+

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/IdeaConfigurationMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/IdeaConfigurationMapper.java
@@ -1,0 +1,30 @@
+package com.skhu.gdgocteambuildingproject.teambuilding.model.mapper;
+
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.ProjectTopic;
+import com.skhu.gdgocteambuildingproject.teambuilding.domain.TeamBuildingProject;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaConfigurationResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.project.ProjectTopicResponseDto;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IdeaConfigurationMapper {
+
+    public IdeaConfigurationResponseDto map(TeamBuildingProject project) {
+        return IdeaConfigurationResponseDto.builder()
+                .topics(mapTopics(project.getTopics()))
+                .availableParts(project.getAvailableParts())
+                .maxMemberCount(project.getMaxMemberCount())
+                .build();
+    }
+
+    private List<ProjectTopicResponseDto> mapTopics(List<ProjectTopic> topics) {
+        return topics.stream()
+                .map(topic -> ProjectTopicResponseDto.builder()
+                        .topicId(topic.getId())
+                        .topic(topic.getTopic())
+                        .build())
+                .toList();
+    }
+}
+

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaService.java
@@ -1,6 +1,7 @@
 package com.skhu.gdgocteambuildingproject.teambuilding.service;
 
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.AdminIdeaDetailResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaConfigurationResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaTitleInfoIncludeDeletedPageResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaTextUpdateRequestDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaUpdateRequestDto;
@@ -18,6 +19,8 @@ public interface IdeaService {
             long userId,
             IdeaCreateRequestDto requestDto
     );
+
+    IdeaConfigurationResponseDto findIdeaConfiguration(long userId);
 
     IdeaTitleInfoPageResponseDto findIdeas(
             long projectId,

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/service/IdeaServiceImpl.java
@@ -25,6 +25,7 @@ import com.skhu.gdgocteambuildingproject.teambuilding.model.mapper.TemporaryIdea
 import java.time.LocalDateTime;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.EnrollmentStatus;
 import com.skhu.gdgocteambuildingproject.teambuilding.domain.enumtype.IdeaStatus;
+import com.skhu.gdgocteambuildingproject.teambuilding.model.mapper.IdeaConfigurationMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.mapper.IdeaDetailInfoMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.mapper.IdeaTitleInfoMapper;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.mapper.RosterMapper;
@@ -48,6 +49,7 @@ import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaUpdateRequest
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaDetailInfoResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaTitleInfoPageResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaTitleInfoResponseDto;
+import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.IdeaConfigurationResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.dto.idea.RosterResponseDto;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.ParticipationUtil;
 import com.skhu.gdgocteambuildingproject.teambuilding.model.ProjectUtil;
@@ -83,6 +85,7 @@ public class IdeaServiceImpl implements IdeaService {
     private final IdeaDetailInfoMapper ideaDetailInfoMapper;
     private final TemporaryIdeaMapper temporaryIdeaMapper;
     private final RosterMapper rosterMapper;
+    private final IdeaConfigurationMapper ideaConfigurationMapper;
 
     @Override
     @Transactional
@@ -110,6 +113,16 @@ public class IdeaServiceImpl implements IdeaService {
                 .orElseGet(() -> saveNewIdea(creator, project, requestDto));
 
         return temporaryIdeaMapper.map(postedIdea);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public IdeaConfigurationResponseDto findIdeaConfiguration(long userId) {
+        TeamBuildingProject currentProject = findCurrentProject();
+
+        participationUtil.validateParticipation(userId, currentProject.getId());
+
+        return ideaConfigurationMapper.map(currentProject);
     }
 
     @Override


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

아이디어 작성(등록) 화면에서 필요한 데이터를 응답하는 API를 구현했습니다.
주제 목록, 모집 가능 파트, 최대 인원수를 응답합니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.