### PR TITLE
feat(mypage): 프로필 조회를 memberId 대신 userId 기반으로 동작하게 변경

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/mypage/api/MypageControllerApi.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/mypage/api/MypageControllerApi.java
@@ -52,11 +52,9 @@ public interface MypageControllerApi {
     );
 
     @Operation(
-            summary = "아이디어 멤버 프로필 조회",
+            summary = "다른 사용자의 프로필 조회",
             description = """
-                    아이디어 멤버 ID를 통해 해당 유저의 프로필을 조회합니다.
-                    
-                    아이디어 멤버와 연결된 유저 객체를 찾아 해당 유저의 프로필 정보를 반환합니다.
+                    다른 사용자의 userId를 통해 해당 유저의 프로필을 조회합니다.
                     """
     )
     @ApiResponse(responseCode = "200")

--- a/src/main/java/com/skhu/gdgocteambuildingproject/mypage/controller/MypageController.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/mypage/controller/MypageController.java
@@ -47,9 +47,9 @@ public class MypageController implements MypageControllerApi {
     }
 
     @Override
-    @GetMapping("/profile/{ideaMemberId}")
-    public ResponseEntity<ProfileInfoResponseDto> getProfileByIdeaMemberId(@PathVariable Long ideaMemberId) {
-        return ResponseEntity.ok(mypageService.getProfileByIdeaMemberId(ideaMemberId));
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<ProfileInfoResponseDto> getProfileByIdeaMemberId(@PathVariable Long userId) {
+        return ResponseEntity.ok(mypageService.getProfileByIdeaMemberId(userId));
     }
 
     @Override

--- a/src/main/java/com/skhu/gdgocteambuildingproject/mypage/service/MypageServiceImpl.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/mypage/service/MypageServiceImpl.java
@@ -14,8 +14,6 @@ import com.skhu.gdgocteambuildingproject.projectgallery.domain.GalleryProject;
 import com.skhu.gdgocteambuildingproject.projectgallery.domain.GalleryProjectMember;
 import com.skhu.gdgocteambuildingproject.projectgallery.domain.enumtype.MemberRole;
 import com.skhu.gdgocteambuildingproject.projectgallery.repository.GalleryProjectMemberRepository;
-import com.skhu.gdgocteambuildingproject.teambuilding.domain.IdeaMember;
-import com.skhu.gdgocteambuildingproject.teambuilding.repository.IdeaMemberRepository;
 import com.skhu.gdgocteambuildingproject.user.domain.TechStack;
 import com.skhu.gdgocteambuildingproject.user.domain.User;
 import com.skhu.gdgocteambuildingproject.user.domain.UserLink;
@@ -23,22 +21,19 @@ import com.skhu.gdgocteambuildingproject.user.domain.enumtype.LinkType;
 import com.skhu.gdgocteambuildingproject.user.domain.enumtype.TechStackType;
 import com.skhu.gdgocteambuildingproject.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MypageServiceImpl implements MypageService {
 
     private final UserRepository userRepository;
-    private final IdeaMemberRepository ideaMemberRepository;
     private final GalleryProjectMemberRepository galleryProjectMemberRepository;
     private final ProfileInfoMapper profileInfoMapper;
     private final ProfileInfoUpdateMapper profileInfoUpdateMapper;
@@ -70,11 +65,11 @@ public class MypageServiceImpl implements MypageService {
 
     @Override
     @Transactional(readOnly = true)
-    public ProfileInfoResponseDto getProfileByIdeaMemberId(Long ideaMemberId) {
-        IdeaMember ideaMember = ideaMemberRepository.findByIdWithUser(ideaMemberId)
-                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.IDEA_MEMBER_NOT_FOUND.getMessage()));
+    public ProfileInfoResponseDto getProfileByIdeaMemberId(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
 
-        return profileInfoMapper.toDto(ideaMember.getUser());
+        return profileInfoMapper.toDto(user);
     }
 
     @Override


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

기존의 멤버 ID 기반 프로필 조회를 유저 ID 기반으로 변경했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.