### PR TITLE
refactor(projectGallery) : mapper 클래스에 멤버 조회 시 기수가 메인 태그인 것만 반환하도록 리펙토링

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/model/mapper/GalleryProjectMemberMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/projectgallery/model/mapper/GalleryProjectMemberMapper.java
@@ -1,29 +1,26 @@
 package com.skhu.gdgocteambuildingproject.projectgallery.model.mapper;
 
+import com.skhu.gdgocteambuildingproject.admin.util.GenerationMapper;
 import com.skhu.gdgocteambuildingproject.projectgallery.domain.GalleryProjectMember;
 import com.skhu.gdgocteambuildingproject.projectgallery.domain.enumtype.MemberRole;
 import com.skhu.gdgocteambuildingproject.projectgallery.dto.member.MemberSearchListResponseDto;
 import com.skhu.gdgocteambuildingproject.projectgallery.dto.member.MemberSearchResponseDto;
 import com.skhu.gdgocteambuildingproject.projectgallery.dto.member.TokenUserInfoForProjectBuildingResponseDto;
-import com.skhu.gdgocteambuildingproject.projectgallery.dto.project.req.GalleryProjectMemberAddDto;
 import com.skhu.gdgocteambuildingproject.projectgallery.dto.project.res.GalleryProjectMemberResponseDto;
 import com.skhu.gdgocteambuildingproject.user.domain.User;
 import com.skhu.gdgocteambuildingproject.user.domain.UserGeneration;
-import com.skhu.gdgocteambuildingproject.user.domain.enumtype.Generation;
-import com.skhu.gdgocteambuildingproject.user.domain.enumtype.UserPosition;
 import com.skhu.gdgocteambuildingproject.user.repository.UserGenerationRepository;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class GalleryProjectMemberMapper {
 
     private final UserGenerationRepository userGenerationRepository;
+    private final GenerationMapper generationMapper;
 
     public List<GalleryProjectMemberResponseDto> mapMembersInfo(List<GalleryProjectMember> members) {
         return members.stream()
@@ -42,8 +39,8 @@ public class GalleryProjectMemberMapper {
     public MemberSearchListResponseDto mapSearchMembers(List<User> users) {
         return mapToListDto(
                 users.stream()
-                .map(this::userFromEntity)
-                .toList());
+                        .map(this::userFromEntity)
+                        .toList());
     }
 
     public TokenUserInfoForProjectBuildingResponseDto mapExhibitor(User user, UserGeneration userGeneration) {
@@ -81,8 +78,10 @@ public class GalleryProjectMemberMapper {
 
     private String joinGenerationAndPositions(User user) {
         return user.getGeneration().stream()
+                .filter(UserGeneration::isMain)
+                .findFirst()
                 .map(gen -> gen.getGeneration().getLabel() + " " + gen.getPosition().name())
-                .collect(Collectors.joining(", "));
+                .orElse("");
     }
 
     private MemberSearchListResponseDto mapToListDto(List<MemberSearchResponseDto> memberSearchResponseDtos) {


### PR DESCRIPTION
## 📝 PR 설명
> 프로젝트 갤러리에서 멤버 검색 시 멤버의 기수역할이 메인태그만 전달되도록 리펙토링 하였습니다

## 🔍 관련 이슈
- #390 

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.