### PR TITLE
feat(team building): 지원 내역 조회 API가 아이디어 ID도 응답하도록 개선

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/enrollment/SentEnrollmentResponseDto.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/dto/enrollment/SentEnrollmentResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 @Builder
 public record SentEnrollmentResponseDto(
         long enrollmentId,
+        long ideaId,
         Choice choice,
         EnrollmentStatus enrollmentStatus,
 

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/SentEnrollmentMapper.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/mapper/SentEnrollmentMapper.java
@@ -37,6 +37,7 @@ public class SentEnrollmentMapper {
 
         return SentEnrollmentResponseDto.builder()
                 .enrollmentId(enrollment.getId())
+                .ideaId(idea.getId())
                 .choice(enrollment.getChoice())
                 .enrollmentStatus(enrollment.getStatus().forApplicant())
                 .ideaTitle(idea.getTitle())


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

지원 내역 API에서, 아이디어 상세조회 페이지로 이동하기 위해 아이디어 ID도 제공하도록 개선했습니다.
