### PR TITLE
feat: 마크다운을 적용할 설명 컬럼 타입을 `LONGTEXT`로 지정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/Idea.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/Idea.java
@@ -49,6 +49,7 @@ public class Idea extends BaseEntity {
     private static final BiFunction<Part, Integer, Integer> INCREASE_COUNT = (part, prevCount) -> prevCount + 1;
 
     private String title;
+    @Column(columnDefinition = "LONGTEXT")
     private String introduction;
     private String description;
     @Builder.Default

--- a/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/User.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/user/domain/User.java
@@ -43,6 +43,7 @@ public class User extends BaseEntity {
     @Column(nullable = true, unique = true)
     private String number;
 
+    @Column(columnDefinition = "LONGTEXT")
     private String introduction;
     private String school;
 


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

긴 내용을 저장할 때 문제가 발생하지 않도록, 마크다운을 적용받는 텍스트에 대한 컬럼 타입을 `LONGTEXT`로 지정했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.