### PR TITLE
fix(admin): 프로젝트의 종료일을, 최종 발표 일정의 시작일이 아닌 종료일로 설정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/domain/TeamBuildingProject.java
@@ -90,7 +90,7 @@ public class TeamBuildingProject extends BaseEntity {
     public LocalDateTime getEndDate() {
         return schedules.stream()
                 .filter(schedule -> schedule.getType() == ScheduleType.FINAL_RESULT_ANNOUNCEMENT)
-                .map(ProjectSchedule::getStartDate)
+                .map(ProjectSchedule::getEndDate)
                 .filter(Objects::nonNull)
                 .findAny()
                 .orElse(null);


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

이전에 최종 발표 일정에 종료일이 추가된 것을 반영하여, 프로젝트의 종료일도 최종 발표 일정의 시작일이 아닌 종료일로 변경했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.