### PR TITLE
fix(team building): 최종 발표 시작일이 아닌 종료일 기준으로 프로젝트를 조회하도록 수정

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
@@ -61,8 +61,8 @@ public class ProjectUtil {
     }
 
     private List<TeamBuildingProject> findUnfinishedProjects() {
-        // 아직 최종 발표 시작일이 지나지 않은 프로젝트들만 조회
-        return projectRepository.findProjectsWithScheduleNotStartedBefore(
+        // 아직 최종 발표 종료일이 지나지 않은 프로젝트들만 조회
+        return projectRepository.findProjectsWithScheduleEndedBefore(
                 ScheduleType.FINAL_RESULT_ANNOUNCEMENT,
                 LocalDateTime.now()
         );


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.
프로젝트 종료 기준이 '최종 발표 시작일'로 설정되어 있던 문제를 해결했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.