### PR TITLE
fix: Jwt 보안 오동작 및 프로젝트 조회 오동작 해결

### DIFF
--- a/src/main/java/com/skhu/gdgocteambuildingproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -21,6 +22,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 @Configuration
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/model/ProjectUtil.java
@@ -62,7 +62,7 @@ public class ProjectUtil {
 
     private List<TeamBuildingProject> findUnfinishedProjects() {
         // 아직 최종 발표 종료일이 지나지 않은 프로젝트들만 조회
-        return projectRepository.findProjectsWithScheduleEndedBefore(
+        return projectRepository.findProjectsWithScheduleNotEndedBefore(
                 ScheduleType.FINAL_RESULT_ANNOUNCEMENT,
                 LocalDateTime.now()
         );

--- a/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/TeamBuildingProjectRepository.java
+++ b/src/main/java/com/skhu/gdgocteambuildingproject/teambuilding/repository/TeamBuildingProjectRepository.java
@@ -53,6 +53,23 @@ public interface TeamBuildingProjectRepository extends JpaRepository<TeamBuildin
         FROM ProjectSchedule s
         WHERE s.project = p
           AND s.type = :type
+          AND (s.endDate IS NULL OR s.endDate > :criteria)
+    )
+    """)
+    List<TeamBuildingProject> findProjectsWithScheduleNotEndedBefore(
+            @Param("type") ScheduleType type,
+            @Param("criteria") LocalDateTime criteria
+    );
+
+    @Query("""
+    SELECT DISTINCT p
+    FROM TeamBuildingProject p
+    LEFT JOIN FETCH p.schedules
+    WHERE EXISTS (
+        SELECT 1
+        FROM ProjectSchedule s
+        WHERE s.project = p
+          AND s.type = :type
           AND s.startDate IS NOT NULL
           AND s.startDate < :criteria
     )


### PR DESCRIPTION
## 📝 PR 설명
> 이번 PR에서 변경된 내용 또는 추가된 기능을 간단히 설명해주세요.

끝나지 않은 프로젝트 조회 메서드가 부적절한 쿼리를 사용하던 문제를 수정했습니다.
`@PreAuthroize`를 사용함에도, `SecurityConfig`에 `@EnableMethodSecurity`가 누락된 문제를 수정했습니다.

## 기타
> 리뷰어가 알아야 할 추가 사항을 작성해주세요.